### PR TITLE
docs(options): correct dimensions default

### DIFF
--- a/website/src/pages/docs/options.mdx
+++ b/website/src/pages/docs/options.mdx
@@ -57,7 +57,7 @@ Remove width and height from root SVG tag.
 
 | Default | CLI Override      | API Override         |
 | ------- | ----------------- | -------------------- |
-| `false` | `--no-dimensions` | `dimensions: <bool>` |
+| `true` | `--no-dimensions` | `dimensions: <bool>` |
 
 ## Expand props
 


### PR DESCRIPTION
## Summary

The docs currently indicate that the default value for dimensions is `false`, but it appears to be `true`: https://github.com/smooth-code/svgr/blob/d112dd287fb1c369bc6caf97807369d827de5528/packages/core/src/config.js#L5
This caused some confusion.

## Test plan

N/A
