### PR TITLE
Display CopyFeedback dialog only once

### DIFF
--- a/website/src/components/playground/Playground.js
+++ b/website/src/components/playground/Playground.js
@@ -250,6 +250,7 @@ export function Playground() {
   const [loading, setLoading] = React.useState(false)
   const [state, setState] = useQuery(getInitialState)
   const dialog = useDialogState({ visible: false })
+  const [dialogDisplayed, setDialogDisplayed] = React.useState(false)
 
   const transformIdRef = React.useRef(0)
 
@@ -321,11 +322,12 @@ export function Playground() {
                 <Box
                   flex={1}
                   position="relative"
-                  onKeyDown={event => {
+                  onKeyDown={dialogDisplayed ? null : event => {
                     // Detect copy
                     if ((event.metaKey || event.ctrlKey) && event.key === 'c') {
                       setTimeout(() => {
                         dialog.show()
+                        setDialogDisplayed(true)
                       }, 50)
                     }
                   }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Thanks for the awesome tool. I've been using the playground to convert svg to jsx and I notice that every time I try to copy the jsx code, this dialog appears

![image](https://user-images.githubusercontent.com/410792/72497636-f7e52d00-3867-11ea-97ab-7488a5e7faec.png)

Ideally it should be displayed only once. This PR implements that change.

## Test plan

Run the website, go to playground, press cmd/ctrl + c, dialog gets displayed. Subsequent cmd/ctrl + c should not display the dialog anymore.