### PR TITLE
Replace `parcel-bundler` with `parcel`

### DIFF
--- a/examples/parcel/package.json
+++ b/examples/parcel/package.json
@@ -3,6 +3,6 @@
   "devDependencies": {
     "@babel/core": "^7.7.7",
     "@svgr/parcel-plugin-svgr": "^4.3.3",
-    "parcel-bundler": "^1.12.4"
+    "parcel": "^1.12.4"
   }
 }

--- a/examples/parcel/yarn.lock
+++ b/examples/parcel/yarn.lock
@@ -3576,10 +3576,10 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
-parcel-bundler@^1.12.4:
+parcel@^1.12.4:
   version "1.12.4"
-  resolved "https://registry.yarnpkg.com/parcel-bundler/-/parcel-bundler-1.12.4.tgz#31223f4ab4d00323a109fce28d5e46775409a9ee"
-  integrity sha512-G+iZGGiPEXcRzw0fiRxWYCKxdt/F7l9a0xkiU4XbcVRJCSlBnioWEwJMutOCCpoQmaQtjB4RBHDGIHN85AIhLQ==
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-1.12.4.tgz#c8136085179c6382e632ca98126093e110be2ac5"
+  integrity sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.4.4"

--- a/packages/parcel-plugin-svgr/package.json
+++ b/packages/parcel-plugin-svgr/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "yarn run build"
   },
   "peerDependencies": {
-    "parcel-bundler": "^1.10.0"
+    "parcel": "^1.10.0"
   },
   "dependencies": {
     "@babel/core": "^7.7.5",
@@ -42,6 +42,6 @@
     "@svgr/plugin-svgo": "^5.1.0"
   },
   "devDependencies": {
-    "parcel-bundler": "^1.10.0"
+    "parcel": "^1.10.0"
   }
 }

--- a/packages/parcel-plugin-svgr/src/asset.js
+++ b/packages/parcel-plugin-svgr/src/asset.js
@@ -1,4 +1,4 @@
-import { Asset } from 'parcel-bundler'
+import { Asset } from 'parcel'
 import { transformAsync, createConfigItem } from '@babel/core'
 import svgo from '@svgr/plugin-svgo'
 import jsx from '@svgr/plugin-jsx'

--- a/packages/parcel-plugin-svgr/src/index.test.js
+++ b/packages/parcel-plugin-svgr/src/index.test.js
@@ -1,4 +1,4 @@
-import Bundler from 'parcel-bundler'
+import Bundler from 'parcel'
 import path from 'path'
 import plugin from '.'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7964,10 +7964,10 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-parcel-bundler@^1.10.0:
+parcel@^1.10.0:
   version "1.12.4"
-  resolved "https://registry.yarnpkg.com/parcel-bundler/-/parcel-bundler-1.12.4.tgz#31223f4ab4d00323a109fce28d5e46775409a9ee"
-  integrity sha512-G+iZGGiPEXcRzw0fiRxWYCKxdt/F7l9a0xkiU4XbcVRJCSlBnioWEwJMutOCCpoQmaQtjB4RBHDGIHN85AIhLQ==
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-1.12.4.tgz#c8136085179c6382e632ca98126093e110be2ac5"
+  integrity sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.4.4"


### PR DESCRIPTION
Fixes #381 

This would probably be a breaking release because it requires users to also replace `parcel-bundler`