### PR TITLE
[Docs] Update contributors link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Please follow the `.prettierrc` in the project.
 
 ## Credits
 
-This project exists thanks to all the people who [contribute](CONTRIBUTING.md). <a href="graphs/contributors"><img src="https://opencollective.com/svgr/contributors.svg?width=890&button=false" /></a>
+This project exists thanks to all the people who [contribute](CONTRIBUTING.md). <a href="https://github.com/gregberge/svgr/graphs/contributors"><img src="https://opencollective.com/svgr/contributors.svg?width=890&button=false" /></a>
 
 ### [Backers](https://opencollective.com/svgr#backer)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

It seems Github may have changed its Contributors URL since this was initially set up. The current `href` directs you to `https://github.com/gregberge/svgr/blob/master/graphs/contributors`, which is a broken page. The functioning page is `https://github.com/gregberge/svgr/graphs/contributors`, so I've inlined it in the `href`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Functionality on master breaks: https://github.com/gregberge/svgr/blob/master/CONTRIBUTING.md#credits

Functionality on fix branch works: https://github.com/michaeljaltamirano/svgr/blob/docs/update-contributors-link/CONTRIBUTING.md#credits
