### PR TITLE
Verify that `svgoConfig.plugins` is an array

### DIFF
--- a/packages/plugin-svgo/src/index.js
+++ b/packages/plugin-svgo/src/index.js
@@ -97,7 +97,13 @@ function getFilePath(state) {
 }
 
 function getPlugins(config) {
-  return config && Array.isArray(config.plugins) ? config.plugins : []
+  if (!config || !config.plugins) {
+    return []
+  }
+  if (!Array.isArray(config.plugins)) {
+    throw Error("`svgoConfig.plugins` must be an array")
+  }
+  return config.plugins
 }
 
 function extendPlugins(...configs) {

--- a/packages/plugin-svgo/src/index.test.js
+++ b/packages/plugin-svgo/src/index.test.js
@@ -38,6 +38,20 @@ describe('svgo', () => {
     expect(result).toMatchSnapshot()
   })
 
+  it('should throw error for invalid config.svgoConfig', () => {
+    const svgoOptions = [
+      baseSvg,
+      {
+        svgo: true,
+        runtimeConfig: true,
+        svgoConfig: { plugins: { removeDesc: false } },
+      },
+      {},
+    ]
+
+    expect(() => svgo(...svgoOptions)).toThrow()
+  })
+
   it('should support icon with config.svgoConfig plugins', () => {
     const result = svgo(
       baseSvg,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

https://github.com/gregberge/svgr/pull/384 introduced a breaking change in the `svgoConfig` parser. Even if this [wasn't intended](https://github.com/gregberge/svgr/pull/384#issuecomment-577043310), using an object for the `plugins` config used to work, and [a lot of people might be using such an incorrect config](https://github.com/gregberge/svgr/pull/384#issuecomment-577584787). The parsing currently fails silently. This PR makes the parser throw an error if anything other than an array is found.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I've written a new test case for handling of incorrect `plugin` configs.
