### PR TITLE
fix(api): Fix typescript types

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.js.snap
@@ -225,7 +225,7 @@ function SvgComponent({
   return <svg><g /></svg>;
 }
 
-const ForwardRef = React.forwardRef((props, ref) => <SvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <SvgComponent svgRef={ref} {...props} />);
 export default ForwardRef;"
 `;
 
@@ -241,15 +241,15 @@ function SvgComponent({
   return <svg><g /></svg>;
 }
 
-const ForwardRef = React.forwardRef((props, ref) => <SvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <SvgComponent svgRef={ref} {...props} />);
 export default ForwardRef;"
 `;
 
 exports[`plugin typescript with "titleProp" adds "titleProp" and "titleId" prop 1`] = `
 "import * as React from \\"react\\";
 interface SVGRProps {
-  title?: String,
-  titleId?: String,
+  title?: string,
+  titleId?: string,
 }
 
 function SvgComponent({
@@ -275,6 +275,6 @@ function SvgComponent({
 }
 
 const MemoSvgComponent = React.memo(SvgComponent);
-const ForwardRef = React.forwardRef((props, ref) => <MemoSvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <MemoSvgComponent svgRef={ref} {...props} />);
 export default ForwardRef;"
 `;

--- a/packages/babel-plugin-transform-svg-component/src/util.js
+++ b/packages/babel-plugin-transform-svg-component/src/util.js
@@ -152,10 +152,10 @@ export const getInterface = ({ types: t }, opts) => {
   }
   if (opts.titleProp) {
     properties.push(
-      objectTypeProperty(t.identifier('title'), t.identifier('String'), true),
+      objectTypeProperty(t.identifier('title'), t.identifier('string'), true),
     )
     properties.push(
-      objectTypeProperty(t.identifier('titleId'), t.identifier('String'), true),
+      objectTypeProperty(t.identifier('titleId'), t.identifier('string'), true),
     )
   }
   if (properties.length === 0) return null
@@ -192,6 +192,11 @@ export const getImport = ({ types: t }, opts) => {
 export const getExport = ({ template }, opts) => {
   let result = ''
   let exportName = opts.state.componentName
+  const plugins = ['jsx']
+
+  if (opts.typescript) {
+    plugins.push('typescript')
+  }
 
   if (opts.memo) {
     const nextExportName = `Memo${exportName}`
@@ -201,7 +206,13 @@ export const getExport = ({ template }, opts) => {
 
   if (opts.ref) {
     const nextExportName = `ForwardRef`
-    result += `const ${nextExportName} = React.forwardRef((props, ref) => <${exportName} svgRef={ref} {...props} />)\n\n`
+    let refType = ''
+
+    if (opts.typescript) {
+      refType = ': React.Ref<SVGSVGElement>'
+    }
+
+    result += `const ${nextExportName} = React.forwardRef((props, ref${refType}) => <${exportName} svgRef={ref} {...props} />)\n\n`
     exportName = nextExportName
   }
 
@@ -209,12 +220,12 @@ export const getExport = ({ template }, opts) => {
     result += `${opts.state.caller.previousExport}\n`
     result += `export { ${exportName} as ReactComponent }`
     return template.ast(result, {
-      plugins: ['jsx'],
+      plugins,
     })
   }
 
   result += `export default ${exportName}`
   return template.ast(result, {
-    plugins: ['jsx'],
+    plugins,
   })
 }

--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -404,6 +404,42 @@ export default SvgFile
 "
 `;
 
+exports[`cli should support various args: --typescript --ref --title-prop 1`] = `
+"import * as React from 'react'
+interface SVGRProps {
+  svgRef?: React.Ref<SVGSVGElement>;
+  title?: string;
+  titleId?: string;
+}
+
+function SvgFile({
+  svgRef,
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) {
+  return (
+    <svg
+      width={48}
+      height={1}
+      ref={svgRef}
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
+    </svg>
+  )
+}
+
+const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => (
+  <SvgFile svgRef={ref} {...props} />
+))
+export default ForwardRef
+
+"
+`;
+
 exports[`cli should support various args: --typescript --ref 1`] = `
 "import * as React from 'react'
 interface SVGRProps {
@@ -421,7 +457,7 @@ function SvgFile({
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref) => (
+const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => (
   <SvgFile svgRef={ref} {...props} />
 ))
 export default ForwardRef

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -133,6 +133,7 @@ describe('cli', () => {
     ['--title-prop'],
     ['--typescript'],
     ['--typescript --ref'],
+    ['--typescript --ref --title-prop'],
   ])(
     'should support various args',
     async args => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

#414 added typescript support (yay!), but there were a couple of incorrect types when the `--typescript` argument was added to the CLI with other args, specifically `--title-prop` & `--ref`. 

For the `--title-prop` arg with `--typescript`, the `title` & `titleId` props added to the `SVGRProps` interface should be `string`, not `String`. The main problem is that the `id` prop in the `<title />` element only takes `string`. But in general `string` should always be used.

For the `--ref` arg with `--typescript` the call to `React.forwardRef` implicitly has a type of `React.Ref<unknown>` but it's being passed to the `svgRef` which has a type of `React.Ref<SVGSVGElement>`.

This PR fixes both of these issues.

## Test plan

I added a new test case for `--typescript --ref --title-prop` in the CLI tests, which generated a new snapshot with the proper typing. I also updated existing snapshots that tested typescript + ref and typescript + title by themselves.

Closes #418.