### PR TITLE
Add `ForeignObject` support for react native

### DIFF
--- a/packages/babel-plugin-transform-react-native-svg/src/index.js
+++ b/packages/babel-plugin-transform-react-native-svg/src/index.js
@@ -21,6 +21,7 @@ const elementToComponent = {
   stop: 'Stop',
   mask: 'Mask',
   image: 'Image',
+  foreignObject: 'ForeignObject',
 }
 
 const expoPrefix = (component, expo) => {


### PR DESCRIPTION
SVGR currently drops `<foreignObject>` tags, even though they're supported by `react-native-svg`.

## Summary

This PR adds `foreignObject` to the map of recognised tags (`elementToComponent`).