### PR TITLE
Add link to VSCode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Quicklinks to some of the most-visited pages:
 - [CLI usage](https://react-svgr.com/docs/cli/)
 - [Webpack usage](https://react-svgr.com/docs/webpack/)
 - [Node usage](https://react-svgr.com/docs/node-api/)
+- [VS-Code Extension](https://marketplace.visualstudio.com/items?itemName=NathHorrigan.code-svgr)
 
 ## Example
 


### PR DESCRIPTION
## Summary

This PR adds a link to the README that points users to the VS-Code extension implementation of SVGR I have worked on. I've gotten some positive feedback on the extension so thought would be good to share a link and make it more easily accessible to devs looking into SVGR and how it can fit into their workflow.

## Test plan

Screenshot from README:
<img width="794" alt="Screenshot 2020-04-21 at 20 21 20" src="https://user-images.githubusercontent.com/13197111/79905112-abccfa00-840d-11ea-8da6-1bda1ed16cc8.png">
