### PR TITLE
fix: typescript config only available in CLI

### DIFF
--- a/website/src/pages/docs/options.mdx
+++ b/website/src/pages/docs/options.mdx
@@ -59,7 +59,8 @@ Generates `.tsx` files with [TypeScript](https://www.typescriptlang.org/) typing
 
 | Default | CLI Override   | API Override         |
 | ------- | -------------- | -------------------- |
-| `false` | `--typescript` | `typescript: <bool>` |
+| `false` | `--typescript` | Only available in CLI |
+
 
 ## Dimensions
 


### PR DESCRIPTION
The option typescript: <boolean> is not working in the svgr config. 

## Summary

This is a update in the docs to explain the API Override to be available in CLI only.

## How to reproduce

In package JSON:

Non working example:
```json
"script": {"build:svg": "svgr icons icons},
 "svgr": {"typescript": true }
```

Working example:
```json
"script": {"build:svg": "svgr icons icons --typescript},
```