### PR TITLE
fix: wrap svg component directly with memo/forwardRef (#440)

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.js.snap
@@ -122,6 +122,20 @@ function SvgComponent({
 export default SvgComponent;"
 `;
 
+exports[`plugin javascript with "titleProp" and "expandProps" adds "titleProp", "titleId" props and expands props 1`] = `
+"import * as React from \\"react\\";
+
+function SvgComponent({
+  title,
+  titleId,
+  ...props
+}) {
+  return <svg><g /></svg>;
+}
+
+export default SvgComponent;"
+`;
+
 exports[`plugin javascript with both "memo" and "ref" option wrap component in "React.memo" and "React.forwardRef" 1`] = `
 "import * as React from \\"react\\";
 
@@ -238,6 +252,24 @@ function SvgComponent({
   title,
   titleId
 }: SVGRProps) {
+  return <svg><g /></svg>;
+}
+
+export default SvgComponent;"
+`;
+
+exports[`plugin typescript with "titleProp" and "expandProps" adds "titleProp", "titleId" props and expands props 1`] = `
+"import * as React from \\"react\\";
+interface SVGRProps {
+  title?: string,
+  titleId?: string,
+}
+
+function SvgComponent({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return <svg><g /></svg>;
 }
 

--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.js.snap
@@ -90,27 +90,22 @@ export default SvgComponent;"
 exports[`plugin javascript with "ref" and "expandProps" option expands props 1`] = `
 "import * as React from \\"react\\";
 
-function SvgComponent({
-  svgRef,
-  ...props
-}) {
+function SvgComponent(props, svgRef) {
   return <svg><g /></svg>;
 }
 
-const ForwardRef = React.forwardRef((props, ref) => <SvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
 
 exports[`plugin javascript with "ref" option adds ForwardRef component 1`] = `
 "import * as React from \\"react\\";
 
-function SvgComponent({
-  svgRef
-}) {
+function SvgComponent(props, svgRef) {
   return <svg><g /></svg>;
 }
 
-const ForwardRef = React.forwardRef((props, ref) => <SvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
 
@@ -130,15 +125,13 @@ export default SvgComponent;"
 exports[`plugin javascript with both "memo" and "ref" option wrap component in "React.memo" and "React.forwardRef" 1`] = `
 "import * as React from \\"react\\";
 
-function SvgComponent({
-  svgRef
-}) {
+function SvgComponent(props, svgRef) {
   return <svg><g /></svg>;
 }
 
-const MemoSvgComponent = React.memo(SvgComponent);
-const ForwardRef = React.forwardRef((props, ref) => <MemoSvgComponent svgRef={ref} {...props} />);
-export default ForwardRef;"
+const ForwardRef = React.forwardRef(SvgComponent);
+const MemoForwardRef = React.memo(ForwardRef);
+export default MemoForwardRef;"
 `;
 
 exports[`plugin typescript custom templates support basic template 1`] = `
@@ -214,34 +207,23 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "ref" and "expandProps" option expands props 1`] = `
 "import * as React from \\"react\\";
-interface SVGRProps {
-  svgRef?: React.Ref<SVGSVGElement>
-}
 
-function SvgComponent({
-  svgRef,
-  ...props
-}: React.SVGProps<SVGSVGElement> & SVGRProps) {
+function SvgComponent(props: React.SVGProps<SVGSVGElement>, svgRef?: React.Ref<SVGSVGElement>) {
   return <svg><g /></svg>;
 }
 
-const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <SvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
 
 exports[`plugin typescript with "ref" option adds ForwardRef component 1`] = `
 "import * as React from \\"react\\";
-interface SVGRProps {
-  svgRef?: React.Ref<SVGSVGElement>
-}
 
-function SvgComponent({
-  svgRef
-}: SVGRProps) {
+function SvgComponent(props: {}, svgRef?: React.Ref<SVGSVGElement>) {
   return <svg><g /></svg>;
 }
 
-const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <SvgComponent svgRef={ref} {...props} />);
+const ForwardRef = React.forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
 
@@ -264,17 +246,12 @@ export default SvgComponent;"
 
 exports[`plugin typescript with both "memo" and "ref" option wrap component in "React.memo" and "React.forwardRef" 1`] = `
 "import * as React from \\"react\\";
-interface SVGRProps {
-  svgRef?: React.Ref<SVGSVGElement>
-}
 
-function SvgComponent({
-  svgRef
-}: SVGRProps) {
+function SvgComponent(props: {}, svgRef?: React.Ref<SVGSVGElement>) {
   return <svg><g /></svg>;
 }
 
-const MemoSvgComponent = React.memo(SvgComponent);
-const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <MemoSvgComponent svgRef={ref} {...props} />);
-export default ForwardRef;"
+const ForwardRef = React.forwardRef(SvgComponent);
+const MemoForwardRef = React.memo(ForwardRef);
+export default MemoForwardRef;"
 `;

--- a/packages/babel-plugin-transform-svg-component/src/index.test.js
+++ b/packages/babel-plugin-transform-svg-component/src/index.test.js
@@ -62,6 +62,17 @@ describe('plugin', () => {
       })
     })
 
+    describe('with "titleProp" and "expandProps"', () => {
+      it('adds "titleProp", "titleId" props and expands props', () => {
+        const { code } = testPlugin(language)('<svg><g /></svg>', {
+          state: { componentName: 'SvgComponent' },
+          expandProps: true,
+          titleProp: true,
+        })
+        expect(code).toMatchSnapshot()
+      })
+    })
+
     describe('with "expandProps"', () => {
       it('add props', () => {
         const { code } = testPlugin(language)('<svg><g /></svg>', {

--- a/packages/babel-plugin-transform-svg-component/src/util.js
+++ b/packages/babel-plugin-transform-svg-component/src/util.js
@@ -120,7 +120,7 @@ export const getProps = ({ types: t }, opts) => {
     opts,
   )
 
-  let args = []
+  const args = []
   if (opts.expandProps || props.length > 0 || opts.ref)
     args.push(typedPropsArgument)
 

--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -235,7 +235,7 @@ exports[`cli should support various args: --native --ref 1`] = `
 "import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
 
-function SvgFile({ svgRef, ...props }) {
+function SvgFile(props, svgRef) {
   return (
     <Svg width={48} height={1} ref={svgRef} {...props}>
       <Path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
@@ -243,9 +243,7 @@ function SvgFile({ svgRef, ...props }) {
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref) => (
-  <SvgFile svgRef={ref} {...props} />
-))
+const ForwardRef = React.forwardRef(SvgFile)
 export default ForwardRef
 
 "
@@ -339,7 +337,7 @@ export default SvgFile
 exports[`cli should support various args: --ref 1`] = `
 "import * as React from 'react'
 
-function SvgFile({ svgRef, ...props }) {
+function SvgFile(props, svgRef) {
   return (
     <svg width={48} height={1} ref={svgRef} {...props}>
       <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
@@ -347,9 +345,7 @@ function SvgFile({ svgRef, ...props }) {
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref) => (
-  <SvgFile svgRef={ref} {...props} />
-))
+const ForwardRef = React.forwardRef(SvgFile)
 export default ForwardRef
 
 "
@@ -407,17 +403,14 @@ export default SvgFile
 exports[`cli should support various args: --typescript --ref --title-prop 1`] = `
 "import * as React from 'react'
 interface SVGRProps {
-  svgRef?: React.Ref<SVGSVGElement>;
   title?: string;
   titleId?: string;
 }
 
-function SvgFile({
-  svgRef,
-  title,
-  titleId,
-  ...props
-}: React.SVGProps<SVGSVGElement> & SVGRProps) {
+function SvgFile(
+  { title, titleId, ...props }: React.SVGProps<SVGSVGElement> & SVGRProps,
+  svgRef?: React.Ref<SVGSVGElement>,
+) {
   return (
     <svg
       width={48}
@@ -432,9 +425,7 @@ function SvgFile({
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => (
-  <SvgFile svgRef={ref} {...props} />
-))
+const ForwardRef = React.forwardRef(SvgFile)
 export default ForwardRef
 
 "
@@ -442,14 +433,11 @@ export default ForwardRef
 
 exports[`cli should support various args: --typescript --ref 1`] = `
 "import * as React from 'react'
-interface SVGRProps {
-  svgRef?: React.Ref<SVGSVGElement>;
-}
 
-function SvgFile({
-  svgRef,
-  ...props
-}: React.SVGProps<SVGSVGElement> & SVGRProps) {
+function SvgFile(
+  props: React.SVGProps<SVGSVGElement>,
+  svgRef?: React.Ref<SVGSVGElement>,
+) {
   return (
     <svg width={48} height={1} ref={svgRef} {...props}>
       <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
@@ -457,9 +445,7 @@ function SvgFile({
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => (
-  <SvgFile svgRef={ref} {...props} />
-))
+const ForwardRef = React.forwardRef(SvgFile)
 export default ForwardRef
 
 "

--- a/packages/core/src/__snapshots__/convert.test.js.snap
+++ b/packages/core/src/__snapshots__/convert.test.js.snap
@@ -192,7 +192,7 @@ exports[`convert config should support options 8 1`] = `
 "import * as React from 'react'
 import Svg, { G, Path } from 'react-native-svg'
 
-function SvgComponent({ svgRef, ...props }) {
+function SvgComponent(props, svgRef) {
   return (
     <Svg width={88} height={88} ref={svgRef} {...props}>
       <G
@@ -208,9 +208,7 @@ function SvgComponent({ svgRef, ...props }) {
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref) => (
-  <SvgComponent svgRef={ref} {...props} />
-))
+const ForwardRef = React.forwardRef(SvgComponent)
 export default ForwardRef
 "
 `;
@@ -218,7 +216,7 @@ export default ForwardRef
 exports[`convert config should support options 9 1`] = `
 "import * as React from 'react'
 
-function SvgComponent({ svgRef, ...props }) {
+function SvgComponent(props, svgRef) {
   return (
     <svg width={88} height={88} ref={svgRef} {...props}>
       <g
@@ -234,9 +232,7 @@ function SvgComponent({ svgRef, ...props }) {
   )
 }
 
-const ForwardRef = React.forwardRef((props, ref) => (
-  <SvgComponent svgRef={ref} {...props} />
-))
+const ForwardRef = React.forwardRef(SvgComponent)
 export default ForwardRef
 "
 `;


### PR DESCRIPTION
## Summary

Already described in: #440 - there is also a demo :D

### Root cause for the typescript error
By wrapping the svg component in a new component at https://github.com/gregberge/svgr/blob/6e7e6b2e73d26d30f64604e0fc627f9ff94079c2/packages/babel-plugin-transform-svg-component/src/util.js#L215 the generic types of React.forwardRef loose the prop types from the svg component. 

### Solution
This fix directly wraps the component in React.forwardRef without something in between. Not wrapping the component in an empty proxy component also has a slight performance advantage. To accomplish the direct wrap with React.forwardRef I also had to change the order with React.memo: React.forwardRef has to be the first wrapper around the svg component because React.memo itself doesnt forward the ref further - the difference can be seen here: https://github.com/gregberge/svgr/pull/441/files#diff-fd642229e3068089af3cc1b24827673aR147

### Output changes

To summarize what this changes in the svg component (`taken from "plugin typescript with "ref" and "expandProps" option expands props 1" before/after snapshots`):

OLD:
```tsx
interface SVGRProps {
  svgRef?: React.Ref<SVGSVGElement>
}

function SvgComponent({
  svgRef,
  ...props
}: React.SVGProps<SVGSVGElement> & SVGRProps) {
  return <svg><g /></svg>;
}

const ForwardRef = React.forwardRef((props, ref: React.Ref<SVGSVGElement>) => <SvgComponent svgRef={ref} {...props} />);
export default ForwardRef;
```

NEW:

```tsx
function SvgComponent(props: React.SVGProps<SVGSVGElement>, svgRef?: React.Ref<SVGSVGElement>) {
  return <svg><g /></svg>;
}

const ForwardRef = React.forwardRef(SvgComponent);
export default ForwardRef;
```
Of course this is only one of many option combinations that had slight changes as seen in the `test` commits, but it gives a good overview.

## Test plan

I tested it with `yarn test` and also tried it out with several builds using feather-icons.
