### PR TITLE
Fixes a bug in parcel-plugin-svgr (it outputs JS instead of SVG when importing from CSS)

### DIFF
--- a/packages/parcel-plugin-svgr/src/asset.js
+++ b/packages/parcel-plugin-svgr/src/asset.js
@@ -29,7 +29,7 @@ const babelOptions = {
 }
 
 class ReactSVGAsset extends Asset {
-  type = 'js'
+  type = 'svg'
 
   async parse(contents) {
     const code = await convert(
@@ -50,7 +50,10 @@ class ReactSVGAsset extends Asset {
   }
 
   async generate() {
-    return [{ type: 'js', value: this.ast }]
+    return [
+      { type: 'svg', value: this.contents },  // original SVG (for CSS imports)
+      { type: 'js', value: this.ast }         // transformed AST (for JS imports)
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary

When importing SVG files from CSS, `parcel-plugin-svgr` erroneously outputs JS. It should only output JS when importing SVG files from JavaScript.

## Test plan

index.css:
```css
body {
    background-image: url('./icon.svg');
}
```

index.html:
```html
<html>
    <head>
        <link rel="stylesheet" type="text/css" href="index.css" />
    </head>
    <body></body>
</html>
```

Normally, upon bundling, it should output this (as seen in Chrome DevTools):

<img width="368" alt="Screen Shot 2020-05-02 at 17 13 24" src="https://user-images.githubusercontent.com/1707/80866702-d84c0600-8c98-11ea-947f-fbd7c86dc8cc.png">

But with `parcel-plugin-svgr` it outputs this, which is obviously wrong and doesn't get loaded/displayed correctly:

<img width="364" alt="Screen Shot 2020-05-02 at 17 15 44" src="https://user-images.githubusercontent.com/1707/80866718-e8fc7c00-8c98-11ea-8875-b4f7d3181e83.png">

## The fix

The fix is to change the main output type of the Asset to `svg`, and output the original svg as is. Output the transformed JS as an alternative rendition:

```js
return [
      { type: 'svg', value: this.contents },  // original SVG (for CSS imports)
      { type: 'js', value: this.ast }         // transformed AST (for JS imports)
    ]
```

This is basically covered by the Parcel documentation, see the example here: https://parceljs.org/asset_types.html





