### PR TITLE
Use fs.promises in svgr cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,8 +39,7 @@
     "chalk": "^4.0.0",
     "commander": "^5.1.0",
     "dashify": "^2.0.0",
-    "glob": "^7.1.4",
-    "output-file-sync": "^2.0.1"
+    "glob": "^7.1.4"
   },
   "devDependencies": {
     "del": "^5.0.0"

--- a/packages/cli/src/dirCommand.js
+++ b/packages/cli/src/dirCommand.js
@@ -1,18 +1,13 @@
 /* eslint-disable no-underscore-dangle, no-console */
-import fs from 'fs'
-import { promisify } from 'util'
+import { promises as fs } from 'fs'
 import path from 'path'
 import chalk from 'chalk'
-import outputFileSync from 'output-file-sync'
 import { loadConfig } from '@svgr/core'
-import { convertFile, stat, transformFilename, CASE, politeWrite } from './util'
-
-const access = promisify(fs.access)
-const readdir = promisify(fs.readdir)
+import { convertFile, transformFilename, CASE, politeWrite } from './util'
 
 async function exists(file) {
   try {
-    await access(file)
+    await fs.access(file)
     return true
   } catch (error) {
     return false
@@ -67,7 +62,8 @@ export default async function dirCommand(
       return { transformed: false, dest }
     }
 
-    outputFileSync(dest, code)
+    await fs.mkdir(path.dirname(dest), { recursive: true })
+    await fs.writeFile(dest, code)
     politeWrite(program, chalk.white(logOutput))
     return { transformed: true, dest }
   }
@@ -76,15 +72,15 @@ export default async function dirCommand(
     const indexFile = path.join(dest, `index.${ext}`)
     const config = loadConfig.sync(options, { filePath: indexFile })
     const indexTemplate = config.indexTemplate || defaultIndexTemplate
-    fs.writeFileSync(indexFile, indexTemplate(files))
+    await fs.writeFile(indexFile, indexTemplate(files))
   }
 
   async function handle(filename, root) {
-    const stats = await stat(filename)
+    const stats = await fs.stat(filename)
 
     if (stats.isDirectory()) {
       const dirname = filename
-      const files = await readdir(dirname)
+      const files = await fs.readdir(dirname)
       const results = await Promise.all(
         files.map(async (relativeFile) => {
           const absFile = path.join(dirname, relativeFile)
@@ -106,7 +102,7 @@ export default async function dirCommand(
 
   await Promise.all(
     filenames.map(async (file) => {
-      const stats = await stat(file)
+      const stats = await fs.stat(file)
       const root = stats.isDirectory() ? file : path.dirname(file)
       await handle(file, root)
     }),

--- a/packages/cli/src/fileCommand.js
+++ b/packages/cli/src/fileCommand.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import { stat, convert, convertFile, exitError } from './util'
+import { promises as fs } from 'fs'
+import { convert, convertFile, exitError } from './util'
 
 async function output(promise) {
   process.stdout.write(`${await promise}\n`)
@@ -38,7 +39,7 @@ async function fileCommand(program, filenames, config) {
   }
 
   const [filename] = filenames
-  const stats = await stat(filename)
+  const stats = await fs.stat(filename)
 
   if (stats.isDirectory()) {
     exitError('Directory are not supported without `--out-dir` option instead.')

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -7,6 +7,7 @@ import { loadConfig } from '@svgr/core'
 import pkg from '../package.json'
 import fileCommand from './fileCommand'
 import dirCommand from './dirCommand'
+import { exitError } from './util'
 
 function noUndefinedKeys(obj) {
   return Object.entries(obj).reduce((obj, [key, value]) => {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -2,12 +2,11 @@
 import program from 'commander'
 import path from 'path'
 import glob from 'glob'
-import fs from 'fs'
+import fs, { promises as fsPromises } from 'fs'
 import { loadConfig } from '@svgr/core'
 import pkg from '../package.json'
 import fileCommand from './fileCommand'
 import dirCommand from './dirCommand'
-import { stat, exitError } from './util'
 
 function noUndefinedKeys(obj) {
   return Object.entries(obj).reduce((obj, [key, value]) => {
@@ -129,7 +128,7 @@ async function run() {
   await Promise.all(
     filenames.map(async (filename) => {
       try {
-        await stat(filename)
+        await fsPromises.stat(filename)
       } catch (error) {
         errors.push(`${filename} does not exist`)
       }

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -1,10 +1,9 @@
-import fs from 'fs'
+import { promises as fs } from 'fs'
 import path from 'path'
 import childProcess from 'child_process'
 import util from 'util'
 import del from 'del'
 
-const readdir = util.promisify(fs.readdir)
 const exec = util.promisify(childProcess.exec)
 
 const svgr = path.join(__dirname, 'index.js')
@@ -152,7 +151,7 @@ describe('cli', () => {
       const outDir = `__fixtures_build__/filename-case-${index}`
       await del(outDir)
       await cli(`${args} ${inDir} --out-dir=${outDir}`)
-      expect(await readdir(outDir)).toMatchSnapshot(args)
+      expect(await fs.readdir(outDir)).toMatchSnapshot(args)
     },
     10000,
   )
@@ -162,14 +161,14 @@ describe('cli', () => {
     const outDir = '__fixtures_build__/ext'
     await del(outDir)
     await cli(`--ext=ts ${inDir} --out-dir=${outDir}`)
-    expect(await readdir(outDir)).toMatchSnapshot()
+    expect(await fs.readdir(outDir)).toMatchSnapshot()
   }, 10000)
 
   it('should support "--ignore-existing"', async () => {
     const inDir = '__fixtures__/simple'
     const outDir = '__fixtures__/simple-existing'
     await cli(`${inDir} --out-dir=${outDir} --ignore-existing`)
-    const content = fs.readFileSync(path.join(outDir, 'File.js'), 'utf-8')
+    const content = await fs.readFile(path.join(outDir, 'File.js'), 'utf-8')
     expect(content).toBe('// nothing')
   }, 10000)
 
@@ -185,7 +184,7 @@ describe('cli', () => {
     const outDir = `__fixtures_build__/prefix-exports`
     await del(outDir)
     await cli(`${inDir} --out-dir=${outDir}`)
-    const content = fs.readFileSync(path.join(outDir, 'index.js'), 'utf-8')
+    const content = await fs.readFile(path.join(outDir, 'index.js'), 'utf-8')
     expect(content).toMatchSnapshot()
   }, 10000)
 
@@ -196,7 +195,7 @@ describe('cli', () => {
     await cli(
       `${inDir} --out-dir=${outDir} --config-file=__fixtures__/custom-index.config.js`,
     )
-    const content = fs.readFileSync(path.join(outDir, 'index.js'), 'utf-8')
+    const content = await fs.readFile(path.join(outDir, 'index.js'), 'utf-8')
     expect(content).toMatchSnapshot()
   }, 10000)
 
@@ -207,7 +206,7 @@ describe('cli', () => {
     await cli(
       `${inDir} --out-dir=${outDir} --index-template=__fixtures__/custom-index-template.js`,
     )
-    const content = fs.readFileSync(path.join(outDir, 'index.js'), 'utf-8')
+    const content = await fs.readFile(path.join(outDir, 'index.js'), 'utf-8')
     expect(content).toMatchSnapshot()
   }, 10000)
 })

--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import fs from 'fs'
+import { promises as fs } from 'fs'
 import chalk from 'chalk'
 import util from 'util'
 import svgrConvert from '@svgr/core'
@@ -8,9 +8,6 @@ import jsx from '@svgr/plugin-jsx'
 import prettier from '@svgr/plugin-prettier'
 import camelcase from 'camelcase'
 import dashify from 'dashify'
-
-export const readFile = util.promisify(fs.readFile)
-export const stat = util.promisify(fs.stat)
 
 export const CASE = {
   KEBAB: 'kebab', // kebab-case
@@ -42,7 +39,7 @@ export function convert(code, config, state) {
 }
 
 export async function convertFile(filePath, config = {}) {
-  const code = await readFile(filePath, 'utf-8')
+  const code = await fs.readFile(filePath, 'utf-8')
   return convert(code, config, { filePath })
 }
 

--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { promises as fs } from 'fs'
 import chalk from 'chalk'
-import util from 'util'
 import svgrConvert from '@svgr/core'
 import svgo from '@svgr/plugin-svgo'
 import jsx from '@svgr/plugin-jsx'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4230,7 +4230,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4271,11 +4271,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4374,11 +4369,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -5932,7 +5922,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6058,7 +6048,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7830,15 +7820,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -7948,22 +7929,6 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -8054,7 +8019,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -8086,7 +8051,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8303,15 +8268,6 @@ osenv@^0.1.4, osenv@^0.1.5:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
-
-output-file-sync@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
-  integrity sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==
-  dependencies:
-    graceful-fs "^4.1.11"
-    is-plain-obj "^1.1.0"
-    mkdirp "^0.5.1"
 
 p-cancelable@^0.4.0:
   version "0.4.1"
@@ -9372,16 +9328,6 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -9813,7 +9759,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -9938,7 +9884,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -9972,7 +9918,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10609,11 +10555,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -10722,7 +10663,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Node v10 got fs.promises support with already promisified api. See here https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_promises_api

Also we get helpful mkdir recursive flag which replaces mkdirp and
make-dir packages.

In this diff I replaced util.promisify with fs.promises where possible
and output-file-sync with combination of promisified fs.mkdir and fs.writeFile.
