### PR TITLE
Update custom-templates.mdx

### DIFF
--- a/website/src/pages/docs/custom-templates.mdx
+++ b/website/src/pages/docs/custom-templates.mdx
@@ -113,6 +113,8 @@ When you use the CLI with `--out-dir` option, an index file is automatically gen
 The customization is the same, a file that exports a function:
 
 ```js
+const path = require('path')
+
 function defaultIndexTemplate(filePaths) {
   const exportEntries = filePaths.map(filePath => {
     const basename = path.basename(filePath, path.extname(filePath))


### PR DESCRIPTION
## Summary

For an example in `website/src/pages/docs/custom-templates.mdx`, the variable `path` is not defined. This PR adds it.

## Test plan

I have copy-pasted the template and now it works.
