### PR TITLE
docs(website): change binary name to svgr

### DIFF
--- a/website/src/pages/docs/cli.mdx
+++ b/website/src/pages/docs/cli.mdx
@@ -19,7 +19,9 @@ yarn add @svgr/cli --dev
 ## Usage
 
 ```bash
-npx @svgr/cli icons/clock-icon.svg
+npx svgr icons/clock-icon.svg
+# or use yarn
+yarn svgr icons/clock-icon.svg
 ```
 
 ## Recipes


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Improve documentation regarding running `cli`, because the binary name is wrong and forces to reinstalling of the library. 
https://github.com/gregberge/svgr/blob/master/packages/cli/package.json#L26

## Test plan
**Before:**
![](https://i.imgur.com/XKcQQ8R.gif)
**After:**
![](https://i.imgur.com/piwFmrj.gif)