### PR TITLE
Fix: ensure a valid name for exports

### DIFF
--- a/packages/cli/src/dirCommand.js
+++ b/packages/cli/src/dirCommand.js
@@ -3,7 +3,13 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import { loadConfig } from '@svgr/core'
-import { convertFile, transformFilename, CASE, politeWrite } from './util'
+import {
+  convertFile,
+  transformFilename,
+  CASE,
+  politeWrite,
+  formatExportName,
+} from './util'
 
 async function exists(file) {
   try {
@@ -33,7 +39,7 @@ export function isCompilable(filename) {
 function defaultIndexTemplate(filePaths) {
   const exportEntries = filePaths.map((filePath) => {
     const basename = path.basename(filePath, path.extname(filePath))
-    const exportName = /^\d/.test(basename) ? `Svg${basename}` : basename
+    const exportName = formatExportName(basename)
     return `export { default as ${exportName} } from './${basename}'`
   })
   return exportEntries.join('\n')

--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -52,3 +52,19 @@ export function politeWrite(program, data) {
     process.stdout.write(data)
   }
 }
+
+export function formatExportName(name) {
+  if (/[-]/g.test(name) && /^\d/.test(name)) {
+    return `Svg${camelcase(name, { pascalCase: true })}`
+  }
+
+  if (/^\d/.test(name)) {
+    return `Svg${name}`
+  }
+
+  if (/[-]/g.test(name)) {
+    return camelcase(name, { pascalCase: true })
+  }
+
+  return name
+}

--- a/packages/cli/src/util.test.js
+++ b/packages/cli/src/util.test.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import { convertFile, transformFilename, CASE } from './util'
+import { convertFile, transformFilename, CASE, formatExportName } from './util'
 
 const FIXTURES = path.join(__dirname, '../../../__fixtures__')
 
@@ -29,6 +29,14 @@ describe('util', () => {
       expect(transformFilename('foo_bar', CASE.CAMEL)).toBe('fooBar')
       expect(transformFilename('foo_bar', CASE.KEBAB)).toBe('foo-bar')
       expect(transformFilename('foo_bar', CASE.PASCAL)).toBe('FooBar')
+    })
+  })
+
+  describe('#formatExportName', () => {
+    it('should ensure a valid export name', () => {
+      expect(formatExportName('foo-bar')).toBe('FooBar')
+      expect(formatExportName('2foo')).toBe('Svg2foo')
+      expect(formatExportName('2foo-bar')).toBe('Svg2FooBar')
     })
   })
 })


### PR DESCRIPTION
## Summary

The PR is motivated by this issue: [https://github.com/gregberge/svgr/issues/481](https://github.com/gregberge/svgr/issues/481)

## Test plan

The code is quite simple, if the name starts with a number and/or has a hyphen it modifies it, otherwise, it returns the original, I have added the tests and everything seems to work perfectly, I hope it is helpful! 😀
