### PR TITLE
Fix exports in index when using --filename-case option

### DIFF
--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -84,6 +84,34 @@ export default SvgFile
 "
 `;
 
+exports[`cli should support custom --filename-case in index.js 1`] = `
+"export { default as PascalCase } from './PascalCase'
+export { default as CamelCase } from './CamelCase'
+export { default as KebabCase } from './KebabCase'
+export { default as MultipleDashes } from './MultipleDashes'"
+`;
+
+exports[`cli should support custom --filename-case in index.js 2`] = `
+"export { default as PascalCase } from './pascalCase'
+export { default as CamelCase } from './camelCase'
+export { default as KebabCase } from './kebabCase'
+export { default as MultipleDashes } from './multipleDashes'"
+`;
+
+exports[`cli should support custom --filename-case in index.js 3`] = `
+"export { default as PascalCase } from './PascalCase'
+export { default as CamelCase } from './CamelCase'
+export { default as KebabCase } from './KebabCase'
+export { default as MultipleDashes } from './MultipleDashes'"
+`;
+
+exports[`cli should support custom --filename-case in index.js 4`] = `
+"export { default as PascalCase } from './pascal-case'
+export { default as CamelCase } from './camel-case'
+export { default as KebabCase } from './kebab-case'
+export { default as MultipleDashes } from './multiple-dashes'"
+`;
+
 exports[`cli should support custom file extension 1`] = `
 Array [
   "File.ts",

--- a/packages/cli/src/dirCommand.js
+++ b/packages/cli/src/dirCommand.js
@@ -2,6 +2,7 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import chalk from 'chalk'
+import camelcase from 'camelcase'
 import { loadConfig } from '@svgr/core'
 import { convertFile, transformFilename, CASE, politeWrite } from './util'
 
@@ -33,7 +34,12 @@ export function isCompilable(filename) {
 function defaultIndexTemplate(filePaths) {
   const exportEntries = filePaths.map((filePath) => {
     const basename = path.basename(filePath, path.extname(filePath))
-    const exportName = /^\d/.test(basename) ? `Svg${basename}` : basename
+    const componentName = camelcase(basename, {
+      pascalCase: true,
+    })
+    const exportName = /^\d/.test(componentName)
+      ? `Svg${componentName}`
+      : componentName
     return `export { default as ${exportName} } from './${basename}'`
   })
   return exportEntries.join('\n')

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -209,4 +209,22 @@ describe('cli', () => {
     const content = await fs.readFile(path.join(outDir, 'index.js'), 'utf-8')
     expect(content).toMatchSnapshot()
   }, 10000)
+
+  it.each([
+    [0, ''],
+    [1, '--filename-case=camel'],
+    [2, '--filename-case=pascal'],
+    [3, '--filename-case=kebab'],
+  ])(
+    'should support custom --filename-case in index.js',
+    async (index, args) => {
+      const inDir = '__fixtures__/cased'
+      const outDir = `__fixtures_build__/filename-case-${index}`
+      await del(outDir)
+      await cli(`${args} ${inDir} --out-dir=${outDir}`)
+      const content = await fs.readFile(path.join(outDir, 'index.js'), 'utf-8')
+      expect(content).toMatchSnapshot()
+    },
+    10000,
+  )
 })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Using the `--filename-case` option with kebab-case would break exports from the generated index file as it would use the filename as the export name. It doesn't break for PascalCase and camelCase, though in the case of camelCase, the export would also be camelCased even though it should always use PascalCase.

I'm not extremely happy with the solution, as I'd much rather abstract it away from `defaultIndexTemplate`, but that would require a breaking change which I don't think is worth it.

Another solution I was thinking about is using `export * from './icon-name'` (also requires a breaking change) but the generated icon component files are using export default and the component names include a prefix like `Svg` and/or `Memo` when using momoization etc. which the index file strips away.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I've added snapshot tests :)
