### PR TITLE
Fix array syntax for SVG in CSS example

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -103,7 +103,7 @@ By default, `@svgr/webpack` includes a `babel-loader` with [an optimized configu
 It is possible to detect the module that requires your SVG using [`Rule.issuer`](https://webpack.js.org/configuration/module/#rule-issuer) in Webpack. Using it you can specify two different configurations for JavaScript and the rest of your files.
 
 ```js
-{
+[
   {
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
     issuer: {
@@ -115,7 +115,7 @@ It is possible to detect the module that requires your SVG using [`Rule.issuer`]
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
     loader: 'url-loader'
   },
-}
+]
 ```
 
 ## License


### PR DESCRIPTION
Noticed in the example for handling SVG in CSS that it should be an array with 2 objects.