### PR TITLE
docs: require('@svgr/rollup') should be require('@svgr/rollup').default

### DIFF
--- a/website/src/pages/docs/rollup.mdx
+++ b/website/src/pages/docs/rollup.mdx
@@ -21,7 +21,7 @@ yarn add @svgr/rollup --dev
 In your `rollup.config.js`:
 
 ```js
-const svgr = require('@svgr/rollup')
+const svgr = require('@svgr/rollup').default
 
 {
   plugins: [svgr()]


### PR DESCRIPTION
When I was loading `@svgr/rollup` in my rollup config, it said that `svgr` is not a function.

When I did the require via the node CLI, i noticed the following
```
Welcome to Node.js v14.15.1.
Type ".help" for more information.
> require("@svgr/rollup")
{ __esModule: true, default: [Function: svgrPlugin] }
> 
```

This PR corrects the documentation for this.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
