### PR TITLE
make contributions easier via fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,23 @@
+tasks:
+  - command: gp await-port 8000 && sleep 3 && gp preview $(gp url 8000)
+  - name: Docs
+    before: cd website
+    init: | 
+      yarn install
+      gp sync-done boot
+    command: yarn dev
+
+  - name: Dev
+    init: | 
+      gp sync-await boot
+      yarn install
+    command: yarn run dev
+    openMode: split-right
+
+ports: 
+  - port: 8000
+    onOpen: ignore
+
+vscode:
+  extensions:
+    - esbenp.prettier-vscode@5.7.1:4Zx39KyQMoIz7x94PSmDmQ==

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,17 @@ We expect project participants to adhere to our Code of Conduct. Please read [th
 
 All work on SVGR happens directly on [GitHub](/). Both core team members and external contributors send pull requests which go through the same review process.
 
+### Online one click Setup
+
+You can use Gitpod(An Online Open Source VS Code like IDE which is free for Open Source) for contributing online. With a single click it will start a workspace and automatically: 
+
+- clone the `svgr` repo.
+- install all the dependencies in `/` and `/website`.
+- run `yarn dev` in `/`.
+- run `yarn dev` in `/website` to start the dev server.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Workflow and Pull Requests
 
 _Before_ submitting a pull request, please make sure the following is done…

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 [![Dependencies](https://img.shields.io/david/gregberge/svgr.svg?path=packages%2Fcore)](https://david-dm.org/gregberge/svgr?path=packages/core)
 [![DevDependencies](https://img.shields.io/david/dev/gregberge/svgr.svg)](https://david-dm.org/gregberge/svgr?type=dev)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 [**Try it out online!**](https://react-svgr.com/playground)
 


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `svgr` repo.
- install all the dependencies in `/` and `/website`.
- run `yarn dev` in `/`.
- run `yarn dev` in `/website` to start the dev server.

This way anyone interested in contributing can start straight away without any friction.

![image](https://user-images.githubusercontent.com/46004116/103502579-779e4a00-4e73-11eb-8896-a2d56af8a554.png)

You can give it a try on my fork of the repo via the following link:
 
https://gitpod.io/#https://github.com/nisarhassan12/svgr
