### PR TITLE
Fix formatExportName for single names

### DIFF
--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -62,9 +62,5 @@ export function formatExportName(name) {
     return `Svg${name}`
   }
 
-  if (/[-]/g.test(name)) {
-    return camelcase(name, { pascalCase: true })
-  }
-
-  return name
+  return camelcase(name, { pascalCase: true })
 }

--- a/packages/cli/src/util.test.js
+++ b/packages/cli/src/util.test.js
@@ -34,6 +34,7 @@ describe('util', () => {
 
   describe('#formatExportName', () => {
     it('should ensure a valid export name', () => {
+      expect(formatExportName('foo')).toBe('Foo')
       expect(formatExportName('foo-bar')).toBe('FooBar')
       expect(formatExportName('2foo')).toBe('Svg2foo')
       expect(formatExportName('2foo-bar')).toBe('Svg2FooBar')


### PR DESCRIPTION
## Summary

This PR fixes the `formatExportName` for single names. For example, for names like `foo` it should export `Foo` name instead `foo` as named export in index.js file. This will fix the named exports in index.js.

**Actual output:**

```js
export { default as foo } from './foo'
export { default as bar } from './bar'
export { default as FooBar } from './foo-bar'
```

**Expected output:**

```js
export { default as Foo } from './foo'
export { default as Bar } from './bar'
export { default as FooBar } from './foo-bar'
```

The PR is motivated by this issue: https://github.com/gregberge/svgr/issues/481
