### PR TITLE
Fix XML entities in generated JavaScript

### DIFF
--- a/packages/hast-util-to-babel-ast/package.json
+++ b/packages/hast-util-to-babel-ast/package.json
@@ -31,6 +31,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "@babel/types": "^7.15.4"
+    "@babel/types": "^7.15.4",
+    "entities": "^2.2.0"
   }
 }

--- a/packages/hast-util-to-babel-ast/src/handlers.js
+++ b/packages/hast-util-to-babel-ast/src/handlers.js
@@ -1,4 +1,5 @@
 import * as t from '@babel/types'
+import { decodeXML } from 'entities'
 import all from './all'
 import getAttributes from './getAttributes'
 import { ELEMENT_TAG_NAME_MAPPING } from './mappings'
@@ -24,7 +25,7 @@ export const text = (h, node, parent) => {
     return null
   }
 
-  return t.jsxExpressionContainer(t.stringLiteral(node.value))
+  return t.jsxExpressionContainer(t.stringLiteral(decodeXML(node.value)))
 }
 
 export const element = (h, node, parent) => {

--- a/packages/hast-util-to-babel-ast/src/index.test.js
+++ b/packages/hast-util-to-babel-ast/src/index.test.js
@@ -77,7 +77,7 @@ describe('hast-util-to-babel-ast', () => {
     )
   })
 
-  it('string litterals children of tspan nodes should have decoded XML entities', () => {
+  it('string literals children of tspan nodes should have decoded XML entities', () => {
     const code = `<svg><text><tspan>&lt;</tspan></text></svg>`
     expect(transform(code)).toMatchInlineSnapshot(
       `"<svg><text><tspan>{\\"<\\"}</tspan></text></svg>;"`,

--- a/packages/hast-util-to-babel-ast/src/index.test.js
+++ b/packages/hast-util-to-babel-ast/src/index.test.js
@@ -69,4 +69,18 @@ describe('hast-util-to-babel-ast', () => {
 
     expect(transform(code)).toMatchSnapshot()
   })
+
+  it('string litterals children of text nodes should have decoded XML entities', () => {
+    const code = `<svg><text>&lt;</text></svg>`
+    expect(transform(code)).toMatchInlineSnapshot(
+      `"<svg><text>{\\"<\\"}</text></svg>;"`,
+    )
+  })
+
+  it('string litterals children of tspan nodes should have decoded XML entities', () => {
+    const code = `<svg><text><tspan>&lt;</tspan></text></svg>`
+    expect(transform(code)).toMatchInlineSnapshot(
+      `"<svg><text><tspan>{\\"<\\"}</tspan></text></svg>;"`,
+    )
+  })
 })

--- a/packages/hast-util-to-babel-ast/src/index.test.js
+++ b/packages/hast-util-to-babel-ast/src/index.test.js
@@ -70,7 +70,7 @@ describe('hast-util-to-babel-ast', () => {
     expect(transform(code)).toMatchSnapshot()
   })
 
-  it('string litterals children of text nodes should have decoded XML entities', () => {
+  it('string literals children of text nodes should have decoded XML entities', () => {
     const code = `<svg><text>&lt;</text></svg>`
     expect(transform(code)).toMatchInlineSnapshot(
       `"<svg><text>{\\"<\\"}</text></svg>;"`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4890,6 +4890,11 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
+entities@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"


### PR DESCRIPTION
## Summary

This patch fixes the issue reported in #516. The fix targets `@svgr/hast-util-to-babel-ast`. The handler for XML text parsing now creates a string literal which content is entity-decoded via the [`entities`](https://www.npmjs.com/package/entities) package. The reference for XML entities is available here: https://www.w3.org/TR/REC-xml/#sec-internal-ent
To be fully XML compliant, we would also have to substitute external entities, those declared in the body of the document. However this is a substantial endeavor out of scope of this fix.

## Test plan

Two tests have been added in `hast-util-to-babel-ast` test folder. See capture below:

![image](https://user-images.githubusercontent.com/3646758/116241716-9767bf80-a73b-11eb-9f0d-1cc92513549f.png)

