### PR TITLE
exclude react props from svg tag

### DIFF
--- a/packages/babel-preset/src/index.js
+++ b/packages/babel-preset/src/index.js
@@ -58,14 +58,16 @@ const plugin = (api, opts) => {
   }
 
   if (opts.expandProps) {
-    toAddAttributes = [
-      ...toAddAttributes,
-      {
-        name: 'props',
-        spread: true,
-        position: opts.expandProps,
-      },
-    ]
+    if(opts.expandProps === "start" || opts.expandProps === "end"){
+      toAddAttributes = [
+        ...toAddAttributes,
+        {
+          name: 'props',
+          spread: true,
+          position: opts.expandProps,
+        },
+      ]
+    }
   }
 
   if (!opts.dimensions) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I try to customize transform svg to react component, and make one interactive. I use props to manipulate components. But I belive it isn't nice solution to passing props into root svg element. If you use custom parameters, warnings will appear in the console.
![2021 05 24 18-13-22](https://user-images.githubusercontent.com/22052167/119340988-743e1a80-bcbd-11eb-98b2-ebc2c5b6864b.png) 
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
To solve this problem I suggest to exclude adding props, if options **expandProps** is not equals true, "start" or "end". 