### PR TITLE
Few adjustments for Webpack 5

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -102,15 +102,13 @@ By default, `@svgr/webpack` includes a `babel-loader` with [an optimized configu
 
 ### Handle SVG in CSS, Sass or Less
 
-It is possible to detect the module that requires your SVG using [`Rule.issuer`](https://webpack.js.org/configuration/module/#rule-issuer) in Webpack. Using it you can specify two different configurations for JavaScript and the rest of your files.
+It is possible to detect the module that requires your SVG using [`Rule.issuer`](https://webpack.js.org/configuration/module/#ruleissuer) in Webpack 5. Using it you can specify two different configurations for JavaScript and the rest of your files.
 
 ```js
 [
   {
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-    issuer: {
-      test: /\.jsx?$/
-    },
+    issuer: /\.[jt]sx?$/,
     use: ['babel-loader', '@svgr/webpack', 'url-loader']
   },
   {
@@ -119,6 +117,8 @@ It is possible to detect the module that requires your SVG using [`Rule.issuer`]
   },
 ]
 ```
+
+_[Rule.issuer](https://v4.webpack.js.org/configuration/module/#ruleissuer) in Webpack 4 has additional conditions which are not available in Webpack 5._
 
 ## License
 

--- a/website/src/pages/docs/webpack.mdx
+++ b/website/src/pages/docs/webpack.mdx
@@ -108,20 +108,20 @@ By default, `@svgr/webpack` includes a `babel-loader` with [an optimized configu
 
 ### Handle SVG in CSS, Sass or Less
 
-It is possible to detect the module that requires your SVG using [`Rule.issuer`](https://webpack.js.org/configuration/module/#rule-issuer) in Webpack. Using it you can specify two different configurations for JavaScript and the rest of your files.
+It is possible to detect the module that requires your SVG using [`Rule.issuer`](https://webpack.js.org/configuration/module/#ruleissuer) in Webpack 5. Using it you can specify two different configurations for JavaScript and the rest of your files.
 
 ```js
-{
+[
   {
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-    issuer: {
-      test: /\.jsx?$/
-    },
+    issuer: /\.[jt]sx?$/,
     use: ['babel-loader', '@svgr/webpack', 'url-loader']
   },
   {
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
     loader: 'url-loader'
   },
-}
+]
 ```
+
+_[Rule.issuer](https://v4.webpack.js.org/configuration/module/#ruleissuer) in Webpack 4 has additional conditions which are not available in Webpack 5._


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

After Webpack 5, the `issuer` prop type is no longer supports `{ test: RegExp }` condition. So it's better to keep this repo up to date as well. Since Webpack 4 also supports the example in this PR, I assume it should also cover the Webpack 4 too.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Before:
![image](https://user-images.githubusercontent.com/5789670/120062300-22edac80-c06a-11eb-9983-1944ce482087.png)

After:
![image](https://user-images.githubusercontent.com/5789670/120062309-2c771480-c06a-11eb-95ed-a2d077a1b9e3.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
