### PR TITLE
feat: add skipImport option

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/util.js
+++ b/packages/babel-plugin-transform-svg-component/src/util.js
@@ -177,6 +177,10 @@ export const getInterface = ({ types: t }, opts) => {
 }
 
 export const getImport = ({ types: t }, opts) => {
+  if (opts.skipImport) {
+    return []
+  }
+
   const importDeclarations = [
     t.importDeclaration(
       [t.importNamespaceSpecifier(t.identifier('React'))],


### PR DESCRIPTION
To use with libs other than React, for example Preact.

```js
import svgr from '@svgr/core'
const result = await svgr(code, { skipImport: true })
return `
  import { h } from 'preact'
  ${result}
`
```

This is more flexiable.