### PR TITLE
feat: add "--no-index" option

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,7 @@ Options:
   --replace-attr-values <old=new>  replace an attribute value
   --template <file>                specify a custom template to use
   --index-template <file>          specify a custom index.js template to use
+  --no-index                       disable index file generation
   --title-prop                     create a title element linked with props
   --prettier-config <fileOrJson>   Prettier config
   --no-prettier                    disable Prettier

--- a/packages/cli/src/__snapshots__/index.test.js.snap
+++ b/packages/cli/src/__snapshots__/index.test.js.snap
@@ -18,6 +18,12 @@ export default SvgFile;
 
 exports[`cli should support --index-template in cli 1`] = `"export { File } from './File'"`;
 
+exports[`cli should support --no-index 1`] = `
+Array [
+  "File.js",
+]
+`;
+
 exports[`cli should support --prettier-config as file 1`] = `
 "import * as React from 'react'
 

--- a/packages/cli/src/dirCommand.js
+++ b/packages/cli/src/dirCommand.js
@@ -75,9 +75,8 @@ export default async function dirCommand(
     return { transformed: true, dest }
   }
 
-  async function generateIndex(dest, files) {
+  async function generateIndex(dest, files, config) {
     const indexFile = path.join(dest, `index.${ext}`)
-    const config = loadConfig.sync(options, { filePath: indexFile })
     const indexTemplate = config.indexTemplate || defaultIndexTemplate
     await fs.writeFile(indexFile, indexTemplate(files))
   }
@@ -98,7 +97,10 @@ export default async function dirCommand(
       if (transformed.length) {
         const destFiles = results.map((result) => result.dest).filter(Boolean)
         const dest = path.resolve(opts.outDir, path.relative(root, dirname))
-        await generateIndex(dest, destFiles)
+        const config = loadConfig.sync(options, { filePath: dest })
+        if (config.index) {
+          await generateIndex(dest, destFiles, config)
+        }
       }
       return { transformed: false, dest: null }
     }

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -90,6 +90,7 @@ program
     '--index-template <file>',
     'specify a custom index.js template to use',
   )
+  .option('--no-index', 'disable index file generation')
   .option('--title-prop', 'create a title element linked with props')
   .option(
     '--prettier-config <fileOrJson>',
@@ -198,6 +199,10 @@ async function run() {
       console.error(error.stack)
       process.exit(2)
     }
+  }
+
+  if (opts.index === false) {
+    delete config.index
   }
 
   const command = opts.outDir ? dirCommand : fileCommand

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -209,4 +209,12 @@ describe('cli', () => {
     const content = await fs.readFile(path.join(outDir, 'index.js'), 'utf-8')
     expect(content).toMatchSnapshot()
   }, 10000)
+
+  it('should support --no-index', async () => {
+    const inDir = '__fixtures__/simple'
+    const outDir = `__fixtures_build__/no-index-case`
+    await del(outDir)
+    await cli(`--no-index ${inDir} --out-dir=${outDir}`)
+    expect(await fs.readdir(outDir)).toMatchSnapshot()
+  }, 10000)
 })

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -15,6 +15,7 @@ export const DEFAULT_CONFIG = {
   svgo: true,
   svgoConfig: null,
   template: null,
+  index: false,
   titleProp: false,
   runtimeConfig: true,
   plugins: null,

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -68,6 +68,8 @@ export interface SvgrOpts {
    * https://github.com/gregberge/svgr/blob/main/packages/babel-plugin-transform-svg-component/src/index.js
    */
   template?: TemplateFunc
+  /** Disable index file generation. */
+  index?: boolean
   /** Output files into a directory. */
   outDir?: string
   /**

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -188,6 +188,14 @@ Specify a template function (API) to change default index.js output (when --out-
 | ------------------------------------------------------------------------------------------------ | ------------------ | -------------------------- |
 | [`basic template`](https://github.com/gregberge/svgr/blob/master/packages/cli/src/dirCommand.js) | `--index-template` | indexTemplate: files => '' |
 
+## index.js file
+
+Disable index.js file generation
+
+| Default | CLI Override | API Override    |
+| ------- | ------------ | --------------- |
+| `false` | `--no-index` | `index: <bool>` |
+
 ## Ignore existing
 
 When used with `--out-dir`, it ignores already existing files.


### PR DESCRIPTION
## Summary

Add `--no-index` option that allows disabling the index file generation.
This PR solves this [issue](https://github.com/gregberge/svgr/issues/589).

## Test plan

<img width="352" alt="Screen Shot 2021-10-11 at 07 33 48" src="https://user-images.githubusercontent.com/9275105/136776248-a1c9ffe7-eff4-4f91-9ba3-ad948bfff452.png">


