### PR TITLE
Small text fix in migrate.mdx

### DIFF
--- a/website/pages/docs/migrate.mdx
+++ b/website/pages/docs/migrate.mdx
@@ -122,4 +122,4 @@ import { transform } from '@svgr/core'
 
 ## ES Modules
 
-SVGR v6 will be the latest version to support CommonJS. If you are still using CommonJS you should [Get Ready For ESM](https://blog.sindresorhus.com/get-ready-for-esm-aa53530b3f77) as soon as possible.
+SVGR v6 will be the last version to support CommonJS. If you are still using CommonJS you should [Get Ready For ESM](https://blog.sindresorhus.com/get-ready-for-esm-aa53530b3f77) as soon as possible.


### PR DESCRIPTION
## Summary

I think this meant to say that it is the "last" version to support CommonJS, not "latest"

