### PR TITLE
Small text fix in custom-templates.mdx

### DIFF
--- a/website/pages/docs/custom-templates.mdx
+++ b/website/pages/docs/custom-templates.mdx
@@ -54,7 +54,7 @@ const propTypesTemplate = (
   { imports, interfaces, componentName, props, jsx, exports },
   { tpl },
 ) => {
-  return tpl.ast`${imports}
+  return tpl`${imports}
 import PropTypes from 'prop-types';
 ${interfaces}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

I tried using the example code [here](https://react-svgr.com/docs/custom-templates/) and noticed that the docs still refer to `tpl.ast` which no longer exists on the template context argument.
