### PR TITLE
docs: correct the resourceQuery comment in code

### DIFF
--- a/website/pages/docs/webpack.mdx
+++ b/website/pages/docs/webpack.mdx
@@ -82,7 +82,7 @@ module.exports = {
     rules: [
       {
         type: 'asset',
-        resourceQuery: /url/, // *.svg?react
+        resourceQuery: /url/, // *.svg?url
       },
       {
         test: /\.svg$/i,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The [doc page of webpack](https://react-svgr.com/docs/webpack/#use-svgr-and-asset-svg-in-the-same-project) has incorrect  resourceQuery comment in code section.

```js
module.exports = {
  module: {
    rules: [
      {
        type: 'asset',
        resourceQuery: /url/, // *.svg?react
      },
      {
        test: /\.svg$/i,
        issuer: /\.[jt]sx?$/,
        use: ['@svgr/webpack'],
      },
    ],
  },
}
```
```js
import svg from './assets/file.svg?url'
import Svg from './assets/file.svg'

const App = () => {
  return (
    <div>
      <img src={svg} width="200" height="200" />
      <Svg width="200" height="200" viewBox="0 0 3500 3500" />
    </div>
  )
}
```

Changed it from `// *.svg?react` to  `// *.svg?url`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
