### PR TITLE
Fixes for rollup plugin

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -36,6 +36,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.14.5",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",
+    "@babel/preset-typescript": "^7.16.0",
     "@svgr/core": "^6.1.1",
     "@svgr/plugin-jsx": "^6.1.0",
     "@svgr/plugin-svgo": "^6.1.0",

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -72,7 +72,7 @@ const plugin: PluginImpl<Options> = (options = {}) => {
         if (!result?.code) {
           throw new Error(`Error while transforming using Babel`)
         }
-        return { code: result.code }
+        return { code: result.code, map: null }
       }
 
       return {
@@ -84,6 +84,7 @@ const plugin: PluginImpl<Options> = (options = {}) => {
           body: [],
         },
         code: jsCode,
+        map: null
       }
     },
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR fixes 1 bug and 1 warning:
1. Bug https://github.com/gregberge/svgr/issues/651 - missing dependency
2. Fix for the warnings that rollup shows in console:
<img width="1101" alt="Screenshot 2021-12-08 at 10 10 03" src="https://user-images.githubusercontent.com/334851/145180809-b013f4d3-259d-4425-84ef-88877cc14ae8.png">

## Test plan

It should not break any existing tests.
