### PR TITLE
[Documentation] Update SVGO Usage + Repo Links

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -83,7 +83,7 @@ If you prefer named export in any case, you may set the `exportType` option to `
 
 ### Use your own Babel configuration
 
-By default, `@svgr/webpack` includes a `babel-loader` with [an optimized configuration](https://github.com/gregberge/svgr/blob/master/packages/webpack/src/index.js). In some case you may want to apply a custom one (if you are using Preact for an example). You can turn off Babel transformation by specifying `babel: false` in options.
+By default, `@svgr/webpack` includes a `babel-loader` with [an optimized configuration](https://github.com/gregberge/svgr/blob/main/packages/webpack/src/index.ts). In some case you may want to apply a custom one (if you are using Preact for an example). You can turn off Babel transformation by specifying `babel: false` in options.
 
 ```js
 // Example using preact

--- a/website/pages/docs/configuration-files.mdx
+++ b/website/pages/docs/configuration-files.mdx
@@ -53,9 +53,9 @@ expandProps: false
 
 ## SVGO
 
-The recommended way to configure SVGO for SVGR is to use [`.svgo.yml`](https://github.com/svg/svgo/blob/master/.svgo.yml). [Several formats are supported](./packages/core/src/plugins/svgo.js) and it is relative to the transformed SVG file.
+The recommended way to configure SVGO for SVGR is to use [`svgo.config.js`](https://github.com/svg/svgo/blob/main/README.md#configuration).
 
-Even if it is not recommended, you can also use `svgoConfig` option to specify your SVGO configuration. `svgoConfig` has precedence on `.svgo.yml`.
+Even if it is not recommended, you can also use `svgoConfig` option to specify your SVGO configuration. `svgoConfig` has precedence on `svgo.config.js`.
 
 ## Prettier
 

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -180,11 +180,11 @@ Add title tag via title property. If titleProp is set to true and no title is pr
 
 ## Template
 
-Specify a template file (CLI) or a template function (API) to use. For an example of template, see [the default one](https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-svg-component/src/index.js).
+Specify a template file (CLI) or a template function (API) to use. For an example of template, see [the default one](https://github.com/gregberge/svgr/blob/main/packages/babel-plugin-transform-svg-component/src/defaultTemplate.ts).
 
 | Default                                                                                                                      | CLI Override | API Override       |
 | ---------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------------ |
-| [`basic template`](https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-svg-component/src/index.js) | `--template` | `template: <func>` |
+| [`basic template`](https://github.com/gregberge/svgr/blob/main/packages/babel-plugin-transform-svg-component/src/defaultTemplate.ts) | `--template` | `template: <func>` |
 
 ## Output Directory
 
@@ -200,7 +200,7 @@ Specify a template function (API) to change default index.js output (when --out-
 
 | Default                                                                                          | CLI Override       | API Override               |
 | ------------------------------------------------------------------------------------------------ | ------------------ | -------------------------- |
-| [`basic template`](https://github.com/gregberge/svgr/blob/master/packages/cli/src/dirCommand.js) | `--index-template` | indexTemplate: files => '' |
+| [`basic template`](https://github.com/gregberge/svgr/blob/main/packages/cli/src/dirCommand.ts) | `--index-template` | indexTemplate: files => '' |
 
 ## index.js file
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

I'm updating `@svgr/cli` in a component library repo (https://github.com/curology/radiance-ui/pull/1307) and noticed some stale documentation with either incorrect instructions or out-of-date links. 

SVGO v2 has deprecated `.yml` files in favor of `.js` files (https://github.com/svg/svgo/commit/b1dafc67805a5637c940379d7576ac201675a79a removed the `.svgo.yml` file that was linked to, https://github.com/svg/svgo/pull/1328 mentions that config file can only be `js` now, etc.), and while Github is pretty good at directing links pointing to `master` to `main`, since this repo now uses `main`, it *does not* do this for `.js` files converted to `.ts`, and so those links are broken.

This PR updates both issues to try and make the docs less broken + more helpful to users working with this library.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

N/A. It would be nice to make some of these links, both external and internal, more robust, but I don't have a good idea how to do that 🙂 🙃 
