### PR TITLE
fix(cli): pass in parser to prettier format to avoid deprecation warning

### DIFF
--- a/packages/cli/src/dirCommand.ts
+++ b/packages/cli/src/dirCommand.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs'
 import * as path from 'path'
 import { grey, white } from 'chalk'
 import { loadConfig, Config } from '@svgr/core'
-import { format, resolveConfig, getFileInfo } from 'prettier'
+import { format, resolveConfig } from 'prettier'
 import {
   convertFile,
   transformFilename,
@@ -100,9 +100,8 @@ export const dirCommand: SvgrCommand = async (
       const prettierRcConfig = opts.runtimeConfig
         ? await resolveConfig(filepath, { editorconfig: true })
         : {}
-      const prettierFileInfo = await getFileInfo(filepath)
       return format(fileContent, {
-        parser: prettierFileInfo.inferredParser,
+        filepath,
         ...prettierRcConfig,
         ...opts.prettierConfig,
       })

--- a/packages/cli/src/dirCommand.ts
+++ b/packages/cli/src/dirCommand.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs'
 import * as path from 'path'
 import { grey, white } from 'chalk'
 import { loadConfig, Config } from '@svgr/core'
-import { format, resolveConfig } from 'prettier'
+import { format, resolveConfig, getFileInfo } from 'prettier'
 import {
   convertFile,
   transformFilename,
@@ -100,7 +100,9 @@ export const dirCommand: SvgrCommand = async (
       const prettierRcConfig = opts.runtimeConfig
         ? await resolveConfig(filepath, { editorconfig: true })
         : {}
+      const prettierFileInfo = await getFileInfo(filepath)
       return format(fileContent, {
+        parser: prettierFileInfo.inferredParser,
         ...prettierRcConfig,
         ...opts.prettierConfig,
       })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Prettier now gives warning when not being able to infer correct parser for files. It can infer by checking filepath or when explicitly setting parser. See issue and comment: https://github.com/prettier/prettier/issues/4763#issuecomment-409662425

This causes outputs such as:

![Screenshot 2022-01-06 at 11 07 37](https://user-images.githubusercontent.com/606374/148366241-da57bcd7-d871-4891-abed-47ab8f9c7de0.png)

There are different ways to solve this:

1. Pass in filename and let parser be inferred in format.
2. Fetch inferred parser and pass in explicit parser to format.

In this PR I've chosen the latter option as it feels more explicit. In plugin-prettier it is [hardcoded to babel](https://github.com/gregberge/svgr/blob/main/packages/plugin-prettier/src/index.ts#L15) but as I see it that might not be correct here?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tested by running and verifying that prettier deprecation warning is gone.