### PR TITLE
fix: use .ts extension for generated index

### DIFF
--- a/packages/cli/src/__snapshots__/index.test.ts.snap
+++ b/packages/cli/src/__snapshots__/index.test.ts.snap
@@ -619,3 +619,8 @@ export default SvgComponent
 
 "
 `;
+
+exports[`cli using typescript option, it creates index with \`.ts\` extension 1`] = `
+"export { default as File } from './File'
+"
+`;

--- a/packages/cli/src/dirCommand.ts
+++ b/packages/cli/src/dirCommand.ts
@@ -47,8 +47,11 @@ const defaultIndexTemplate: IndexTemplate = (paths) => {
   return exportEntries.join('\n')
 }
 
-const resolveExtension = (config: Config, ext?: string) =>
-  ext || (config.typescript ? 'tsx' : 'js')
+const resolveExtension = (
+  config: Config,
+  ext: string | null | undefined,
+  jsx: boolean,
+) => ext || (config.typescript ? (jsx ? 'tsx' : 'ts') : 'js')
 
 export const dirCommand: SvgrCommand = async (
   opts,
@@ -64,7 +67,7 @@ export const dirCommand: SvgrCommand = async (
     outDir,
   } = opts
 
-  const ext = resolveExtension(opts, extOpt)
+  const ext = resolveExtension(opts, extOpt, true)
 
   const write = async (src: string, dest: string) => {
     if (!isCompilable(src)) {
@@ -92,6 +95,7 @@ export const dirCommand: SvgrCommand = async (
     files: string[],
     opts: Options,
   ) => {
+    const ext = resolveExtension(opts, extOpt, false)
     const filepath = path.join(dest, `index.${ext}`)
     const indexTemplate = opts.indexTemplate || defaultIndexTemplate
     const fileContent = indexTemplate(files)

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -203,6 +203,15 @@ describe('cli', () => {
     expect(content).toMatchSnapshot()
   })
 
+  it('using typescript option, it creates index with `.ts` extension', async () => {
+    const inDir = '__fixtures__/simple'
+    const outDir = `__fixtures_build__/ts-index`
+    await del(outDir)
+    await cli(`${inDir} --out-dir=${outDir} --typescript`)
+    const content = await fs.readFile(path.join(outDir, 'index.ts'), 'utf-8')
+    expect(content).toMatchSnapshot()
+  })
+
   it('should support --index-template in cli', async () => {
     const inDir = '__fixtures__/simple'
     const outDir = `__fixtures_build__/custom-index-arg`


### PR DESCRIPTION
Fix #462
