### PR TITLE
chore(deps): upgrade deprecated rollup-pluginutils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16807,7 +16807,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -17990,6 +17989,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
       "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
       "dependencies": {
         "estree-walker": "^0.6.1"
       }
@@ -17997,7 +17997,8 @@
     "node_modules/rollup-pluginutils/node_modules/estree-walker": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -20982,10 +20983,10 @@
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.16.0",
+        "@rollup/pluginutils": "^4.1.2",
         "@svgr/core": "^6.2.1",
         "@svgr/plugin-jsx": "^6.2.1",
-        "@svgr/plugin-svgo": "^6.2.0",
-        "rollup-pluginutils": "^2.8.2"
+        "@svgr/plugin-svgo": "^6.2.0"
       },
       "devDependencies": {
         "rollup": "^2.56.3",
@@ -20999,6 +21000,23 @@
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
       }
+    },
+    "packages/rollup/node_modules/@rollup/pluginutils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "packages/rollup/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "packages/webpack": {
       "name": "@svgr/webpack",
@@ -24644,13 +24662,29 @@
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.16.0",
+        "@rollup/pluginutils": "^4.1.2",
         "@svgr/core": "^6.2.1",
         "@svgr/plugin-jsx": "^6.2.1",
         "@svgr/plugin-svgo": "^6.2.0",
         "rollup": "^2.56.3",
         "rollup-plugin-image": "^1.0.2",
-        "rollup-plugin-url": "^3.0.1",
-        "rollup-pluginutils": "^2.8.2"
+        "rollup-plugin-url": "^3.0.1"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+          "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        }
       }
     },
     "@svgr/webpack": {
@@ -33964,8 +33998,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "2.3.0",
@@ -34883,6 +34916,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
       "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       },
@@ -34890,7 +34924,8 @@
         "estree-walker": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
         }
       }
     },

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -37,10 +37,10 @@
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.16.0",
+    "@rollup/pluginutils": "^4.1.2",
     "@svgr/core": "^6.2.1",
     "@svgr/plugin-jsx": "^6.2.1",
-    "@svgr/plugin-svgo": "^6.2.0",
-    "rollup-pluginutils": "^2.8.2"
+    "@svgr/plugin-svgo": "^6.2.0"
   },
   "devDependencies": {
     "rollup": "^2.56.3",

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import { transform, Config } from '@svgr/core'
-import { createFilter, CreateFilter } from 'rollup-pluginutils'
+import { createFilter, CreateFilter } from '@rollup/pluginutils'
 import { transformAsync, createConfigItem } from '@babel/core'
 import svgo from '@svgr/plugin-svgo'
 import jsx from '@svgr/plugin-jsx'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

[`rollup-pluginutils`](https://www.npmjs.com/package/rollup-pluginutils) has been renamed to [`@rollup/pluginutils`](https://www.npmjs.com/package/@rollup/pluginutils)

Fixes #686

## Test plan

Same module, same function, same signature, just renamed.
Ran `npm test` and `npm run build`, both passed.
