### PR TITLE
Update webpack docs when using SVGR and asset SVG in the same project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 __fixtures_build__/
 src/__fixtures__/dist/
 coverage/
+
+# Ignore MacOS specific files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ dist/
 __fixtures_build__/
 src/__fixtures__/dist/
 coverage/
-
-# Ignore MacOS specific files
-.DS_Store

--- a/website/pages/docs/webpack.mdx
+++ b/website/pages/docs/webpack.mdx
@@ -81,12 +81,14 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.svg$/i,
         type: 'asset',
         resourceQuery: /url/, // *.svg?url
       },
       {
         test: /\.svg$/i,
         issuer: /\.[jt]sx?$/,
+        resourceQuery: { not: [/url/] }, // exclude react component if *.svg?url
         use: ['@svgr/webpack'],
       },
     ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
When trying to use webpack 5's `resourceQuery` as defined in the previous docs, I kept getting a base64 string of the compiled react component not the svg.

This ended up erroring out all usage of `import svg from 'my-svg.svg?url` since it wasn't actually a base64 of the xml svg. I updated the docs with the fix I used to only have the svgr loader called when the resourceQuery is not url.

Also updated the`.gitignore` to ignore MacOS specific files in the future.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
The `examples/webpack` didn't use the `resourceQuery` option so the only edits were made to the documentation text. I ran the gatsby doc app locally to check that it works and reflected the change in the right spot and then linted/tested the entire repo.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
