### PR TITLE
fix(core): types path in package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "engines": {
     "node": ">=10"
   },
-  "types": "lib/index.d.ts",
+  "types": "./dist/index.d.ts",
   "homepage": "https://react-svgr.com",
   "funding": {
     "type": "github",


### PR DESCRIPTION
## Summary

The `lib/index.d.ts` file is not included in the npm package dist, correct the `types` file path in the `package.json` , same as the `typings` field.