### PR TITLE
feat: add a copy button in the playground jsx output header

### DIFF
--- a/website/src/components/playground/Playground.js
+++ b/website/src/components/playground/Playground.js
@@ -73,17 +73,28 @@ const FloatingAd = styled.div`
   width: 400;
 `
 
-const EditorTitle = styled.h3`
+const EditorTitleContainer = styled.div`
   padding: 0 2;
   font-size: 12;
   height: 28;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   text-transform: uppercase;
-  font-weight: bold;
   border-bottom: 1;
   border-color: layout-border;
   color: on-background-light;
+`
+
+const EditorTitle = styled.h3`
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+`
+
+const EditorTitleButton = styled.button`
+  border-radius: 4;
+  height: 20;
 `
 
 const InnerDialog = styled.div`
@@ -236,6 +247,9 @@ const ClientOnly = ({ children }) => {
   return visible ? children : null
 }
 
+const Copy = 'Copy'
+const Copied = 'Copied!'
+
 export function Playground() {
   const [input, setInput] = useState(defaultSvg)
   const [output, setOutput] = useState('')
@@ -279,6 +293,20 @@ export function Playground() {
     transform()
   }, [input, JSON.stringify(state)])
 
+  const handleButtonClick = (event) => {
+    navigator.clipboard.writeText(output)
+    !dialogDisplayedRef.current &&
+      setTimeout(() => {
+        dialog.show()
+        dialogDisplayedRef.current = true
+      }, 50)
+    const button = event.target
+    button.innerText = Copied
+    setTimeout(() => {
+      button.innerText = Copy
+    }, 2000)
+  }
+
   return (
     <>
       <GlobalStyle />
@@ -292,7 +320,9 @@ export function Playground() {
           <Suspense fallback={<Loading />}>
             <Editors>
               <EditorContainer>
-                <EditorTitle>SVG input</EditorTitle>
+                <EditorTitleContainer>
+                  <EditorTitle>SVG input</EditorTitle>
+                </EditorTitleContainer>
                 <DropArea onChange={setInput}>
                   <Editor
                     name="input"
@@ -315,7 +345,12 @@ export function Playground() {
                   }
                 }}
               >
-                <EditorTitle>JSX output</EditorTitle>
+                <EditorTitleContainer>
+                  <EditorTitle>JSX output</EditorTitle>
+                  <EditorTitleButton onClick={handleButtonClick}>
+                    {Copy}
+                  </EditorTitleButton>
+                </EditorTitleContainer>
                 <Editor name="output" mode="jsx" readOnly value={output} />
               </EditorContainer>
             </Editors>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
I added a copy button in the playground JSX section so that the generated output can be copied with the click of a button. Please note that the copy feedback is still shown once per session regardless of the copy method, i.e., it works with both the button and/or ```cmd+c```. The button text changes from ```Copy``` to ```Copied!``` for two seconds and resets back to ```Copy```.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

![image](https://user-images.githubusercontent.com/47485043/158008031-971da118-9c2a-4e9b-89a7-97141522912e.png)
![image](https://user-images.githubusercontent.com/47485043/158008046-2cca4f5c-88e7-4183-b4b0-6ef47881171b.png)

Please advice if anything else is needed for this section.
