### PR TITLE
chore(cli): output file name when error happen to handling a file

### DIFF
--- a/packages/cli/src/dirCommand.ts
+++ b/packages/cli/src/dirCommand.ts
@@ -146,7 +146,10 @@ export const dirCommand: SvgrCommand = async (
     }
 
     const dest = path.resolve(outDir as string, path.relative(root, filename))
-    return write(filename, dest)
+    return write(filename, dest).catch(err => {
+      console.error('Failed to handle file: ', filename)
+      throw err
+    })
   }
 
   await Promise.all(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

When I use `svgr -d` to convert directory and there is a broken SVG file, the command failed with output:

```
Error in parsing SVG: Unexpected close tag
Line: 0
Column: 1578
Char: >
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```

Can not know which file is wrong.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
