### PR TITLE
feat: add regexp support for the jsx attribute value replacement plugin

### DIFF
--- a/packages/babel-plugin-replace-jsx-attribute-value/README.md
+++ b/packages/babel-plugin-replace-jsx-attribute-value/README.md
@@ -18,7 +18,13 @@ npm install --save-dev @svgr/babel-plugin-replace-jsx-attribute-value
       {
         "values": [
           { "value": "#000", "newValue": "#fff" },
-          { "value": "blue", "newValue": "props.color", "literal": true }
+          { "value": "blue", "newValue": "props.color", "literal": true },
+          {
+            "value": "/#([0-9A-F]{3}){1,2}/g",
+            "regExp": /#([0-9A-F]{3}){1,2}/g,
+            "newValue": "props.color",
+            "literal": true
+          }
         ]
       }
     ]

--- a/packages/babel-plugin-replace-jsx-attribute-value/src/index.test.ts
+++ b/packages/babel-plugin-replace-jsx-attribute-value/src/index.test.ts
@@ -23,5 +23,18 @@ describe('plugin', () => {
         values: [{ value: 'cool', newValue: 'props.color', literal: true }],
       }),
     ).toMatchInlineSnapshot(`"<div something={props.color} />;"`)
+
+    expect(
+      testPlugin('<div something="#FFF" />', {
+        values: [
+          {
+            value: '/#([0-9A-F]{3}){1,2}/g',
+            regExp: /#([0-9A-F]{3}){1,2}/g,
+            newValue: 'props.color',
+            literal: true,
+          },
+        ],
+      }),
+    ).toMatchInlineSnapshot(`"<div something={props.color} />;"`)
   })
 })

--- a/packages/babel-plugin-replace-jsx-attribute-value/src/index.ts
+++ b/packages/babel-plugin-replace-jsx-attribute-value/src/index.ts
@@ -5,13 +5,14 @@ export interface Value {
   value: string
   newValue: string | boolean | number
   literal?: boolean
+  regExp?: RegExp
 }
 
 export interface Options {
   values: Value[]
 }
 
-const addJSXAttribute = (api: ConfigAPI, opts: Options) => {
+const replaceJSXAttribute = (api: ConfigAPI, opts: Options) => {
   const getAttributeValue = (
     value: string | boolean | number,
     literal?: boolean,
@@ -43,8 +44,13 @@ const addJSXAttribute = (api: ConfigAPI, opts: Options) => {
         const valuePath = path.get('value')
         if (!valuePath.isStringLiteral()) return
 
-        opts.values.forEach(({ value, newValue, literal }) => {
-          if (!valuePath.isStringLiteral({ value })) return
+        opts.values.forEach(({ value, newValue, literal, regExp }) => {
+          if (regExp) {
+            if (!valuePath.node.value.match(regExp)) return
+          } else {
+            if (!valuePath.isStringLiteral({ value })) return
+          }
+
           const attributeValue = getAttributeValue(newValue, literal)
           if (attributeValue) {
             valuePath.replaceWith(attributeValue)
@@ -55,4 +61,4 @@ const addJSXAttribute = (api: ConfigAPI, opts: Options) => {
   }
 }
 
-export default addJSXAttribute
+export default replaceJSXAttribute

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -32,6 +32,20 @@ const getAttributeValue = (value: string) => {
   return { value: literal ? value.slice(1, -1) : value, literal }
 }
 
+const parseRegExp = (value: string) => {
+  try {
+    const match = value.match(/^\/(.*)\/{1}([dgimsuy]{0,7})$/)
+
+    if (!match) return null
+
+    const [, pattern, flags] = match
+
+    return new RegExp(pattern, flags)
+  } catch (error) {
+    return null
+  }
+}
+
 const propsToAttributes = (props: { [key: string]: string }): Attribute[] => {
   return Object.keys(props).map((name) => {
     const { literal, value } = getAttributeValue(props[name])
@@ -42,7 +56,10 @@ const propsToAttributes = (props: { [key: string]: string }): Attribute[] => {
 function replaceMapToValues(replaceMap: { [key: string]: string }): Value[] {
   return Object.keys(replaceMap).map((value) => {
     const { literal, value: newValue } = getAttributeValue(replaceMap[value])
-    return { value, newValue, literal }
+
+    const regExp = parseRegExp(value) ?? undefined
+
+    return { value, newValue, literal, regExp }
   })
 }
 

--- a/packages/core/src/__snapshots__/transform.test.ts.snap
+++ b/packages/core/src/__snapshots__/transform.test.ts.snap
@@ -349,6 +349,27 @@ export default ForwardRef
 "
 `;
 
+exports[`convert config accepts options {"replaceAttrValues":{"/^(none)$/g":"black"}} 1`] = `
+"import * as React from 'react'
+
+const SvgComponent = (props) => (
+  <svg width={88} height={88} xmlns=\\"http://www.w3.org/2000/svg\\" {...props}>
+    <g
+      stroke=\\"#063855\\"
+      strokeWidth={2}
+      fill=\\"black\\"
+      fillRule=\\"evenodd\\"
+      strokeLinecap=\\"square\\"
+    >
+      <path d=\\"M51 37 37 51M51 51 37 37\\" />
+    </g>
+  </svg>
+)
+
+export default SvgComponent
+"
+`;
+
 exports[`convert config accepts options {"replaceAttrValues":{"none":"{black}"}} 1`] = `
 "import * as React from 'react'
 

--- a/packages/core/src/transform.test.ts
+++ b/packages/core/src/transform.test.ts
@@ -309,6 +309,7 @@ describe('convert', () => {
       { ref: true },
       { svgProps: { a: 'b', b: '{props.b}' } },
       { replaceAttrValues: { none: 'black' } },
+      { replaceAttrValues: { '/^(none)$/g': 'black' } },
       { replaceAttrValues: { none: '{black}' } },
       { svgo: false },
       { prettier: false },

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -158,7 +158,8 @@ Replace an attribute value by an other. The main usage of this option is to chan
 | ------- | --------------------------------- | ---------------------------------------------- |
 | `[]`    | `--replace-attr-values <old=new>` | `replaceAttrValues: { [key: string]: string }` |
 
-> You can specify dynamic property using curly braces: `{ '#000': "{props.color}" }` or `--replace-attr-values #000={props.color}`. It is particularly useful with a custom template.
+> You can specify dynamic property using curly braces: `{ '#000': "{props.color}" }` or `--replace-attr-values #000={props.color}`. It is particularly useful with a custom template. <br />
+> Also you can use regular expression to replace the value: `{ '/#([0-9A-F]{3}){1,2}/g': "{props.color}" }`
 
 ## SVG props
 


### PR DESCRIPTION
## Summary

Previously it was possible to replace attribute values only with strict string matching. This pr will allow you to use regular expressions.
It's tricky to implement this feature without changing the API and at the same time without degrading performance, so it was decided not to change the cli and wepback API of the plugin, but the babel plugin was modernized. If you use only the babel plugin, you can use the key instead of the specific string value of the regular expression in the `value` property, and use the actual regexp in the `regExp` field.

## Test plan

CLI:
`npx @svgr/cli --replace-attr-values "/#[0-9A-F]{3}/g=green" icon.svg`

Webpack plugin:
`
{
      loader: '@svgr/webpack',
      options: {
            replaceAttrValues: {
                  '/#[0-9A-F]{3}/g': '{props.color}'
            }
      }
}
`