### PR TITLE
feat(descProp): add descProp option

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write \"**/*.{js,json,md}\"",
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "test:c": "jest packages/babel-plugin-svg-dynamic-title --runInBand"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest --runInBand",
-    "test:c": "jest packages/babel-plugin-transform-svg-component --runInBand",
-    "test:cw": "jest packages/babel-plugin-transform-svg-component --runInBand --watch"
+    "test:c": "jest packages/babel-preset --runInBand",
+    "test:cw": "jest packages/babel-preset --runInBand --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest --runInBand",
-    "test:c": "jest packages/babel-plugin-svg-dynamic-title --runInBand",
-    "test:cw": "jest packages/babel-plugin-svg-dynamic-title --runInBand --watch"
+    "test:c": "jest packages/babel-plugin-transform-svg-component --runInBand",
+    "test:cw": "jest packages/babel-plugin-transform-svg-component --runInBand --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest --runInBand",
-    "test:c": "jest packages/babel-preset --runInBand",
-    "test:cw": "jest packages/babel-preset --runInBand --watch"
+    "test:c": "jest packages/core --runInBand",
+    "test:cw": "jest packages/core --runInBand --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest --runInBand",
-    "test:c": "jest packages/babel-plugin-svg-dynamic-title --runInBand"
+    "test:c": "jest packages/babel-plugin-svg-dynamic-title --runInBand",
+    "test:cw": "jest packages/babel-plugin-svg-dynamic-title --runInBand --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest --runInBand",
-    "test:c": "jest packages/core --runInBand",
-    "test:cw": "jest packages/core --runInBand --watch"
+    "test:c": "jest packages/cli --runInBand",
+    "test:cw": "jest packages/cli --runInBand --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "format": "prettier --write \"**/*.{js,json,md}\"",
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
-    "test": "jest --runInBand",
-    "test:c": "jest packages/cli --runInBand",
-    "test:cw": "jest packages/cli --runInBand --watch"
+    "test": "jest --runInBand"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/babel-plugin-svg-dynamic-title/README.md
+++ b/packages/babel-plugin-svg-dynamic-title/README.md
@@ -16,6 +16,10 @@ npm install --save-dev @svgr/babel-plugin-svg-dynamic-title
 }
 ```
 
+## Note
+
+This plugin handles both the titleProp and descProp options. By default, it will handle titleProp only.
+
 ## License
 
 MIT

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
@@ -1,7 +1,7 @@
 import { transform } from '@babel/core'
 import plugin from '.'
 
-const testPlugin = (code: string, tag: string = 'title') => {
+const testPlugin = (code: string, tag = 'title') => {
   const result = transform(code, {
     plugins: ['@babel/plugin-syntax-jsx', tag ? () => plugin(tag) : plugin],
     configFile: false,

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
@@ -1,30 +1,40 @@
 import { transform } from '@babel/core'
 import plugin from '.'
 
-const testPlugin = (code: string) => {
+const testTagPlugin = (code: string, tag: string) => {
   const result = transform(code, {
-    plugins: ['@babel/plugin-syntax-jsx', plugin],
+    plugins: ['@babel/plugin-syntax-jsx', () => plugin(tag)],
     configFile: false,
   })
 
   return result?.code
 }
 
-describe('plugin', () => {
+const testTitlePlugin = (code: string) => {
+  return testTagPlugin(code, 'title')
+}
+
+const testDescPlugin = (code: string) => {
+  return testTagPlugin(code, 'desc')
+}
+
+describe('title plugin', () => {
   it('should add title attribute if not present', () => {
-    expect(testPlugin('<svg></svg>')).toMatchInlineSnapshot(
+    expect(testTitlePlugin('<svg></svg>')).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
 
   it('should add title element and fallback to existing title', () => {
     // testing when the existing title contains a simple string
-    expect(testPlugin(`<svg><title>Hello</title></svg>`)).toMatchInlineSnapshot(
+    expect(
+      testTitlePlugin(`<svg><title>Hello</title></svg>`),
+    ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId}>Hello</title> : title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
     // testing when the existing title contains an JSXExpression
     expect(
-      testPlugin(`<svg><title>{"Hello"}</title></svg>`),
+      testTitlePlugin(`<svg><title>{"Hello"}</title></svg>`),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId}>{\\"Hello\\"}</title> : title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
@@ -32,25 +42,72 @@ describe('plugin', () => {
   it('should preserve any existing title attributes', () => {
     // testing when the existing title contains a simple string
     expect(
-      testPlugin(`<svg><title id='a'>Hello</title></svg>`),
+      testTitlePlugin(`<svg><title id='a'>Hello</title></svg>`),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId || 'a'}>Hello</title> : title ? <title id={titleId || 'a'}>{title}</title> : null}</svg>;"`,
     )
   })
   it('should support empty title', () => {
-    expect(testPlugin('<svg><title></title></svg>')).toMatchInlineSnapshot(
+    expect(testTitlePlugin('<svg><title></title></svg>')).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
   it('should support self closing title', () => {
-    expect(testPlugin('<svg><title /></svg>')).toMatchInlineSnapshot(
+    expect(testTitlePlugin('<svg><title /></svg>')).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
 
   it('should work if an attribute is already present', () => {
-    expect(testPlugin('<svg><foo /></svg>')).toMatchInlineSnapshot(
+    expect(testTitlePlugin('<svg><foo /></svg>')).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}<foo /></svg>;"`,
+    )
+  })
+})
+
+describe('desc plugin', () => {
+  it('should add desc attribute if not present', () => {
+    expect(testDescPlugin('<svg></svg>')).toMatchInlineSnapshot(
+      `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
+    )
+  })
+
+  it('should add desc element and fallback to existing desc', () => {
+    // testing when the existing desc contains a simple string
+    expect(
+      testDescPlugin(`<svg><desc>Hello</desc></svg>`),
+    ).toMatchInlineSnapshot(
+      `"<svg>{desc === undefined ? <desc id={descId}>Hello</desc> : desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
+    )
+    // testing when the existing desc contains an JSXExpression
+    expect(
+      testDescPlugin(`<svg><desc>{"Hello"}</desc></svg>`),
+    ).toMatchInlineSnapshot(
+      `"<svg>{desc === undefined ? <desc id={descId}>{\\"Hello\\"}</desc> : desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
+    )
+  })
+  it('should preserve any existing desc attributes', () => {
+    // testing when the existing desc contains a simple string
+    expect(
+      testDescPlugin(`<svg><desc id='a'>Hello</desc></svg>`),
+    ).toMatchInlineSnapshot(
+      `"<svg>{desc === undefined ? <desc id={descId || 'a'}>Hello</desc> : desc ? <desc id={descId || 'a'}>{desc}</desc> : null}</svg>;"`,
+    )
+  })
+  it('should support empty desc', () => {
+    expect(testDescPlugin('<svg><desc></desc></svg>')).toMatchInlineSnapshot(
+      `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
+    )
+  })
+  it('should support self closing desc', () => {
+    expect(testDescPlugin('<svg><desc /></svg>')).toMatchInlineSnapshot(
+      `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
+    )
+  })
+
+  it('should work if an attribute is already present', () => {
+    expect(testDescPlugin('<svg><foo /></svg>')).toMatchInlineSnapshot(
+      `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}<foo /></svg>;"`,
     )
   })
 })

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
@@ -1,7 +1,7 @@
 import { transform } from '@babel/core'
 import plugin from '.'
 
-const testTagPlugin = (code: string, tag: string) => {
+const testPlugin = (code: string, tag: string) => {
   const result = transform(code, {
     plugins: ['@babel/plugin-syntax-jsx', () => plugin(tag)],
     configFile: false,
@@ -11,11 +11,11 @@ const testTagPlugin = (code: string, tag: string) => {
 }
 
 const testTitlePlugin = (code: string) => {
-  return testTagPlugin(code, 'title')
+  return testPlugin(code, 'title')
 }
 
 const testDescPlugin = (code: string) => {
-  return testTagPlugin(code, 'desc')
+  return testPlugin(code, 'desc')
 }
 
 describe('title plugin', () => {

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
@@ -1,9 +1,9 @@
 import { transform } from '@babel/core'
 import plugin from '.'
 
-const testPlugin = (code: string, tag: string) => {
+const testPlugin = (code: string, tag: string = 'title') => {
   const result = transform(code, {
-    plugins: ['@babel/plugin-syntax-jsx', () => plugin(tag)],
+    plugins: ['@babel/plugin-syntax-jsx', tag ? () => plugin(tag) : plugin],
     configFile: false,
   })
 
@@ -11,7 +11,7 @@ const testPlugin = (code: string, tag: string) => {
 }
 
 const testTitlePlugin = (code: string) => {
-  return testPlugin(code, 'title')
+  return testPlugin(code)
 }
 
 const testDescPlugin = (code: string) => {

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
@@ -1,26 +1,18 @@
 import { transform } from '@babel/core'
-import plugin from '.'
+import plugin, { Options } from '.'
 
-const testPlugin = (code: string, tag = 'title') => {
+const testPlugin = (code: string, options: Options) => {
   const result = transform(code, {
-    plugins: ['@babel/plugin-syntax-jsx', tag ? () => plugin(tag) : plugin],
+    plugins: ['@babel/plugin-syntax-jsx', [plugin, options]],
     configFile: false,
   })
 
   return result?.code
 }
 
-const testTitlePlugin = (code: string) => {
-  return testPlugin(code)
-}
-
-const testDescPlugin = (code: string) => {
-  return testPlugin(code, 'desc')
-}
-
 describe('title plugin', () => {
   it('should add title attribute if not present', () => {
-    expect(testTitlePlugin('<svg></svg>')).toMatchInlineSnapshot(
+    expect(testPlugin('<svg></svg>', { tag: 'title' })).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
@@ -28,13 +20,13 @@ describe('title plugin', () => {
   it('should add title element and fallback to existing title', () => {
     // testing when the existing title contains a simple string
     expect(
-      testTitlePlugin(`<svg><title>Hello</title></svg>`),
+      testPlugin(`<svg><title>Hello</title></svg>`, { tag: 'title' }),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId}>Hello</title> : title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
     // testing when the existing title contains an JSXExpression
     expect(
-      testTitlePlugin(`<svg><title>{"Hello"}</title></svg>`),
+      testPlugin(`<svg><title>{"Hello"}</title></svg>`, { tag: 'title' }),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId}>{\\"Hello\\"}</title> : title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
@@ -42,24 +34,30 @@ describe('title plugin', () => {
   it('should preserve any existing title attributes', () => {
     // testing when the existing title contains a simple string
     expect(
-      testTitlePlugin(`<svg><title id='a'>Hello</title></svg>`),
+      testPlugin(`<svg><title id='a'>Hello</title></svg>`, { tag: 'title' }),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId || 'a'}>Hello</title> : title ? <title id={titleId || 'a'}>{title}</title> : null}</svg>;"`,
     )
   })
   it('should support empty title', () => {
-    expect(testTitlePlugin('<svg><title></title></svg>')).toMatchInlineSnapshot(
+    expect(
+      testPlugin('<svg><title></title></svg>', { tag: 'title' }),
+    ).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
   it('should support self closing title', () => {
-    expect(testTitlePlugin('<svg><title /></svg>')).toMatchInlineSnapshot(
+    expect(
+      testPlugin('<svg><title /></svg>', { tag: 'title' }),
+    ).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
 
   it('should work if an attribute is already present', () => {
-    expect(testTitlePlugin('<svg><foo /></svg>')).toMatchInlineSnapshot(
+    expect(
+      testPlugin('<svg><foo /></svg>', { tag: 'title' }),
+    ).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}<foo /></svg>;"`,
     )
   })
@@ -67,7 +65,7 @@ describe('title plugin', () => {
 
 describe('desc plugin', () => {
   it('should add desc attribute if not present', () => {
-    expect(testDescPlugin('<svg></svg>')).toMatchInlineSnapshot(
+    expect(testPlugin('<svg></svg>', { tag: 'desc' })).toMatchInlineSnapshot(
       `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
     )
   })
@@ -75,13 +73,13 @@ describe('desc plugin', () => {
   it('should add desc element and fallback to existing desc', () => {
     // testing when the existing desc contains a simple string
     expect(
-      testDescPlugin(`<svg><desc>Hello</desc></svg>`),
+      testPlugin(`<svg><desc>Hello</desc></svg>`, { tag: 'desc' }),
     ).toMatchInlineSnapshot(
       `"<svg>{desc === undefined ? <desc id={descId}>Hello</desc> : desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
     )
     // testing when the existing desc contains an JSXExpression
     expect(
-      testDescPlugin(`<svg><desc>{"Hello"}</desc></svg>`),
+      testPlugin(`<svg><desc>{"Hello"}</desc></svg>`, { tag: 'desc' }),
     ).toMatchInlineSnapshot(
       `"<svg>{desc === undefined ? <desc id={descId}>{\\"Hello\\"}</desc> : desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
     )
@@ -89,24 +87,30 @@ describe('desc plugin', () => {
   it('should preserve any existing desc attributes', () => {
     // testing when the existing desc contains a simple string
     expect(
-      testDescPlugin(`<svg><desc id='a'>Hello</desc></svg>`),
+      testPlugin(`<svg><desc id='a'>Hello</desc></svg>`, { tag: 'desc' }),
     ).toMatchInlineSnapshot(
       `"<svg>{desc === undefined ? <desc id={descId || 'a'}>Hello</desc> : desc ? <desc id={descId || 'a'}>{desc}</desc> : null}</svg>;"`,
     )
   })
   it('should support empty desc', () => {
-    expect(testDescPlugin('<svg><desc></desc></svg>')).toMatchInlineSnapshot(
+    expect(
+      testPlugin('<svg><desc></desc></svg>', { tag: 'desc' }),
+    ).toMatchInlineSnapshot(
       `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
     )
   })
   it('should support self closing desc', () => {
-    expect(testDescPlugin('<svg><desc /></svg>')).toMatchInlineSnapshot(
+    expect(
+      testPlugin('<svg><desc /></svg>', { tag: 'desc' }),
+    ).toMatchInlineSnapshot(
       `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;"`,
     )
   })
 
   it('should work if an attribute is already present', () => {
-    expect(testDescPlugin('<svg><foo /></svg>')).toMatchInlineSnapshot(
+    expect(
+      testPlugin('<svg><foo /></svg>', { tag: 'desc' }),
+    ).toMatchInlineSnapshot(
       `"<svg>{desc ? <desc id={descId}>{desc}</desc> : null}<foo /></svg>;"`,
     )
   })

--- a/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.test.ts
@@ -1,7 +1,7 @@
 import { transform } from '@babel/core'
 import plugin, { Options } from '.'
 
-const testPlugin = (code: string, options: Options) => {
+const testPlugin = (code: string, options: Options = {tag: 'title'}) => {
   const result = transform(code, {
     plugins: ['@babel/plugin-syntax-jsx', [plugin, options]],
     configFile: false,
@@ -12,7 +12,7 @@ const testPlugin = (code: string, options: Options) => {
 
 describe('title plugin', () => {
   it('should add title attribute if not present', () => {
-    expect(testPlugin('<svg></svg>', { tag: 'title' })).toMatchInlineSnapshot(
+    expect(testPlugin('<svg></svg>')).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
@@ -20,13 +20,13 @@ describe('title plugin', () => {
   it('should add title element and fallback to existing title', () => {
     // testing when the existing title contains a simple string
     expect(
-      testPlugin(`<svg><title>Hello</title></svg>`, { tag: 'title' }),
+      testPlugin(`<svg><title>Hello</title></svg>`),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId}>Hello</title> : title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
     // testing when the existing title contains an JSXExpression
     expect(
-      testPlugin(`<svg><title>{"Hello"}</title></svg>`, { tag: 'title' }),
+      testPlugin(`<svg><title>{"Hello"}</title></svg>`),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId}>{\\"Hello\\"}</title> : title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
@@ -34,21 +34,21 @@ describe('title plugin', () => {
   it('should preserve any existing title attributes', () => {
     // testing when the existing title contains a simple string
     expect(
-      testPlugin(`<svg><title id='a'>Hello</title></svg>`, { tag: 'title' }),
+      testPlugin(`<svg><title id='a'>Hello</title></svg>`),
     ).toMatchInlineSnapshot(
       `"<svg>{title === undefined ? <title id={titleId || 'a'}>Hello</title> : title ? <title id={titleId || 'a'}>{title}</title> : null}</svg>;"`,
     )
   })
   it('should support empty title', () => {
     expect(
-      testPlugin('<svg><title></title></svg>', { tag: 'title' }),
+      testPlugin('<svg><title></title></svg>'),
     ).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
   })
   it('should support self closing title', () => {
     expect(
-      testPlugin('<svg><title /></svg>', { tag: 'title' }),
+      testPlugin('<svg><title /></svg>'),
     ).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}</svg>;"`,
     )
@@ -56,7 +56,7 @@ describe('title plugin', () => {
 
   it('should work if an attribute is already present', () => {
     expect(
-      testPlugin('<svg><foo /></svg>', { tag: 'title' }),
+      testPlugin('<svg><foo /></svg>'),
     ).toMatchInlineSnapshot(
       `"<svg>{title ? <title id={titleId}>{title}</title> : null}<foo /></svg>;"`,
     )

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -3,8 +3,10 @@ import { NodePath, types as t } from '@babel/core'
 
 const elements = ['svg', 'Svg']
 
+type tag = 'title' | 'desc'
+
 export interface Options {
-  tag: 'title' | 'desc'
+  tag: tag | null
 }
 
 interface State {
@@ -12,7 +14,7 @@ interface State {
 }
 
 const createTagElement = (
-  tag: Options['tag'],
+  tag: tag,
   children: t.JSXExpressionContainer[] = [],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [],
 ) => {
@@ -24,14 +26,14 @@ const createTagElement = (
   )
 }
 
-const createTagIdAttribute = (tag: Options['tag']) =>
+const createTagIdAttribute = (tag: tag) =>
   t.jsxAttribute(
     t.jsxIdentifier('id'),
     t.jsxExpressionContainer(t.identifier(`${tag}Id`)),
   )
 
 const addTagIdAttribute = (
-  tag: Options['tag'],
+  tag: tag,
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[],
 ) => {
   const existingId = attributes.find(
@@ -52,7 +54,7 @@ const addTagIdAttribute = (
 const plugin = () => ({
   visitor: {
     JSXElement(path: NodePath<t.JSXElement>, state: State) {
-      const tag = state.opts.tag
+      const tag = state.opts.tag || 'title'
       if (!elements.length) return
 
       const openingElement = path.get('openingElement')

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -3,25 +3,27 @@ import { NodePath, types as t } from '@babel/core'
 
 const elements = ['svg', 'Svg']
 
-const createTitleElement = (
+const createTagElement = (
+  tag: string,
   children: t.JSXExpressionContainer[] = [],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [],
 ) => {
-  const title = t.jsxIdentifier('title')
+  const eleName = t.jsxIdentifier(tag)
   return t.jsxElement(
-    t.jsxOpeningElement(title, attributes),
-    t.jsxClosingElement(title),
+    t.jsxOpeningElement(eleName, attributes),
+    t.jsxClosingElement(eleName),
     children,
   )
 }
 
-const createTitleIdAttribute = () =>
+const createTagIdAttribute = (tag: string) =>
   t.jsxAttribute(
     t.jsxIdentifier('id'),
-    t.jsxExpressionContainer(t.identifier('titleId')),
+    t.jsxExpressionContainer(t.identifier(`${tag}Id`)),
   )
 
-const addTitleIdAttribute = (
+const addTagIdAttribute = (
+  tag: string,
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[],
 ) => {
   const existingId = attributes.find(
@@ -29,28 +31,23 @@ const addTitleIdAttribute = (
   ) as t.JSXAttribute | undefined
 
   if (!existingId) {
-    return [...attributes, createTitleIdAttribute()]
+    return [...attributes, createTagIdAttribute(tag)]
   }
   existingId.value = t.jsxExpressionContainer(
     t.isStringLiteral(existingId.value)
-      ? t.logicalExpression('||', t.identifier('titleId'), existingId.value)
-      : t.identifier('titleId'),
+      ? t.logicalExpression('||', t.identifier(`${tag}Id`), existingId.value)
+      : t.identifier(`${tag}Id`),
   )
   return attributes
 }
 
-// Aveline-art note: this is the plugin that goes into babel; it has a specific format, and is an object with visitor key.
-// Babel first converts the data into an AST tree. Then the plugins are applied to the tree in order to change the tree. Finaly the AST is changed back into its original data form.
-// Plugins uses visitors, which searches for a type of tree node. If the right one is found, it is transformed by the plugin.
-const plugin = () => ({
+const plugin = (tag: string) => ({
   visitor: {
-    // Aveline-art: the identifier, which takes a node
     JSXElement(path: NodePath<t.JSXElement>) {
       if (!elements.length) return
 
       const openingElement = path.get('openingElement')
       const openingElementName = openingElement.get('name')
-      // Aveline-art: check that the parent element is an svg
       if (
         !elements.some((element) =>
           openingElementName.isJSXIdentifier({ name: element }),
@@ -59,23 +56,24 @@ const plugin = () => ({
         return
       }
 
-      // Aveline-art: a helper function, not used yet
-      const getTitleElement = (
+      const getTagElement = (
         existingTitle?: t.JSXElement,
       ): t.JSXExpressionContainer => {
-        const titleExpression = t.identifier('title')
+        const tagExpression = t.identifier(tag)
         if (existingTitle) {
-          existingTitle.openingElement.attributes = addTitleIdAttribute(
+          existingTitle.openingElement.attributes = addTagIdAttribute(
+            tag,
             existingTitle.openingElement.attributes,
           )
         }
         const conditionalTitle = t.conditionalExpression(
-          titleExpression,
-          createTitleElement(
-            [t.jsxExpressionContainer(titleExpression)],
+          tagExpression,
+          createTagElement(
+            tag,
+            [t.jsxExpressionContainer(tagExpression)],
             existingTitle
               ? existingTitle.openingElement.attributes
-              : [createTitleIdAttribute()],
+              : [createTagIdAttribute(tag)],
           ),
           t.nullLiteral(),
         )
@@ -86,7 +84,7 @@ const plugin = () => ({
             t.conditionalExpression(
               t.binaryExpression(
                 '===',
-                titleExpression,
+                tagExpression,
                 t.identifier('undefined'),
               ),
               existingTitle,
@@ -97,28 +95,26 @@ const plugin = () => ({
         return t.jsxExpressionContainer(conditionalTitle)
       }
 
-      // store the title element,  Aveline-art is null for now
-      let titleElement: t.JSXExpressionContainer | null = null
+      // store the title element
+      let tagElement: t.JSXExpressionContainer | null = null
 
-      // aveline-art check whether a title is in the svgs children
       const hasTitle = path.get('children').some((childPath) => {
-        if (childPath.node === titleElement) return false
+        if (childPath.node === tagElement) return false
         if (!childPath.isJSXElement()) return false
         const name = childPath.get('openingElement').get('name')
         if (!name.isJSXIdentifier()) return false
-        if (name.node.name !== 'title') return false
-        // aveline-art verified that there is a title element, now run the childpath through the helper function, then replace the current AST node with new childpath
-        titleElement = getTitleElement(childPath.node)
-        childPath.replaceWith(titleElement)
+        if (name.node.name !== tag) return false
+        tagElement = getTagElement(childPath.node)
+        childPath.replaceWith(tagElement)
         return true
       })
 
       // create a title element if not already create
-      titleElement = titleElement || getTitleElement()
+      tagElement = tagElement || getTagElement()
       if (!hasTitle) {
         // path.unshiftContainer is not working well :(
         // path.unshiftContainer('children', titleElement)
-        path.node.children.unshift(titleElement)
+        path.node.children.unshift(tagElement)
         path.replaceWith(path.node)
       }
     },

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -4,11 +4,11 @@ import { ConfigAPI, NodePath, types as t } from '@babel/core'
 const elements = ['svg', 'Svg']
 
 export interface Options {
-  tag: string
+  tag: 'title' | 'desc'
 }
 
 const createTagElement = (
-  tag: string,
+  tag: Options['tag'],
   children: t.JSXExpressionContainer[] = [],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [],
 ) => {
@@ -20,14 +20,14 @@ const createTagElement = (
   )
 }
 
-const createTagIdAttribute = (tag: string) =>
+const createTagIdAttribute = (tag: Options['tag']) =>
   t.jsxAttribute(
     t.jsxIdentifier('id'),
     t.jsxExpressionContainer(t.identifier(`${tag}Id`)),
   )
 
 const addTagIdAttribute = (
-  tag: string,
+  tag: Options['tag'],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[],
 ) => {
   const existingId = attributes.find(

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -39,13 +39,18 @@ const addTitleIdAttribute = (
   return attributes
 }
 
+// Aveline-art note: this is the plugin that goes into babel; it has a specific format, and is an object with visitor key.
+// Babel first converts the data into an AST tree. Then the plugins are applied to the tree in order to change the tree. Finaly the AST is changed back into its original data form.
+// Plugins uses visitors, which searches for a type of tree node. If the right one is found, it is transformed by the plugin.
 const plugin = () => ({
   visitor: {
+    // Aveline-art: the identifier, which takes a node
     JSXElement(path: NodePath<t.JSXElement>) {
       if (!elements.length) return
 
       const openingElement = path.get('openingElement')
       const openingElementName = openingElement.get('name')
+      // Aveline-art: check that the parent element is an svg
       if (
         !elements.some((element) =>
           openingElementName.isJSXIdentifier({ name: element }),
@@ -54,6 +59,7 @@ const plugin = () => ({
         return
       }
 
+      // Aveline-art: a helper function, not used yet
       const getTitleElement = (
         existingTitle?: t.JSXElement,
       ): t.JSXExpressionContainer => {
@@ -91,15 +97,17 @@ const plugin = () => ({
         return t.jsxExpressionContainer(conditionalTitle)
       }
 
-      // store the title element
+      // store the title element,  Aveline-art is null for now
       let titleElement: t.JSXExpressionContainer | null = null
 
+      // aveline-art check whether a title is in the svgs children
       const hasTitle = path.get('children').some((childPath) => {
         if (childPath.node === titleElement) return false
         if (!childPath.isJSXElement()) return false
         const name = childPath.get('openingElement').get('name')
         if (!name.isJSXIdentifier()) return false
         if (name.node.name !== 'title') return false
+        // aveline-art verified that there is a title element, now run the childpath through the helper function, then replace the current AST node with new childpath
         titleElement = getTitleElement(childPath.node)
         childPath.replaceWith(titleElement)
         return true

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -45,7 +45,7 @@ const addTagIdAttribute = (
   return attributes
 }
 
-const plugin = (_: ConfigAPI, opts: Options = { tag: 'title' }) => ({
+const plugin = (_: ConfigAPI, opts: Options) => ({
   visitor: {
     JSXElement(path: NodePath<t.JSXElement>) {
       if (!elements.length) return

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -4,7 +4,7 @@ import { NodePath, types as t } from '@babel/core'
 const elements = ['svg', 'Svg']
 
 const createTagElement = (
-  tag = 'title',
+  tag: string,
   children: t.JSXExpressionContainer[] = [],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [],
 ) => {
@@ -41,7 +41,7 @@ const addTagIdAttribute = (
   return attributes
 }
 
-const plugin = (tag: string) => ({
+const plugin = (tag = 'title') => ({
   visitor: {
     JSXElement(path: NodePath<t.JSXElement>) {
       if (!elements.length) return

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -4,7 +4,7 @@ import { NodePath, types as t } from '@babel/core'
 const elements = ['svg', 'Svg']
 
 const createTagElement = (
-  tag: string,
+  tag: string = 'title',
   children: t.JSXExpressionContainer[] = [],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [],
 ) => {

--- a/packages/babel-plugin-svg-dynamic-title/src/index.ts
+++ b/packages/babel-plugin-svg-dynamic-title/src/index.ts
@@ -4,7 +4,7 @@ import { NodePath, types as t } from '@babel/core'
 const elements = ['svg', 'Svg']
 
 const createTagElement = (
-  tag: string = 'title',
+  tag = 'title',
   children: t.JSXExpressionContainer[] = [],
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [],
 ) => {

--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
@@ -97,6 +97,29 @@ const SvgComponent = () => <svg><g /></svg>;
 export default SvgComponent;"
 `;
 
+exports[`plugin javascript with "descProp" adds "desc" and "descId" prop 1`] = `
+"import * as React from \\"react\\";
+
+const SvgComponent = ({
+  desc,
+  descId
+}) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
+exports[`plugin javascript with "descProp" and "expandProps" adds "desc", "descId" props and expands props 1`] = `
+"import * as React from \\"react\\";
+
+const SvgComponent = ({
+  desc,
+  descId,
+  ...props
+}) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
 exports[`plugin javascript with "expandProps" add props 1`] = `
 "import * as React from \\"react\\";
 
@@ -194,7 +217,21 @@ const ForwardRef = forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
 
-exports[`plugin javascript with "titleProp" adds "titleProp" and "titleId" prop 1`] = `
+exports[`plugin javascript with "titleProp" "descProp" and "expandProps" adds "title", "titleId", "desc", "descId" props and expands props 1`] = `
+"import * as React from \\"react\\";
+
+const SvgComponent = ({
+  title,
+  titleId,
+  desc,
+  descId,
+  ...props
+}) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
+exports[`plugin javascript with "titleProp" adds "title" and "titleId" prop 1`] = `
 "import * as React from \\"react\\";
 
 const SvgComponent = ({
@@ -205,7 +242,20 @@ const SvgComponent = ({
 export default SvgComponent;"
 `;
 
-exports[`plugin javascript with "titleProp" and "expandProps" adds "titleProp", "titleId" props and expands props 1`] = `
+exports[`plugin javascript with "titleProp" and "descProp" adds "title", "titleId", "desc", and "descId prop 1`] = `
+"import * as React from \\"react\\";
+
+const SvgComponent = ({
+  title,
+  titleId,
+  desc,
+  descId
+}) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
+exports[`plugin javascript with "titleProp" and "expandProps" adds "title", "titleId" props and expands props 1`] = `
 "import * as React from \\"react\\";
 
 const SvgComponent = ({
@@ -325,6 +375,38 @@ const SvgComponent = () => <svg><g /></svg>;
 export default SvgComponent;"
 `;
 
+exports[`plugin typescript with "descProp" adds "desc" and "descId" prop 1`] = `
+"import * as React from \\"react\\";
+interface SVGRProps {
+  desc?: string;
+  descId?: string;
+}
+
+const SvgComponent = ({
+  desc,
+  descId
+}: SVGRProps) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
+exports[`plugin typescript with "descProp" and "expandProps" adds "desc", "descId" props and expands props 1`] = `
+"import * as React from \\"react\\";
+import { SVGProps } from \\"react\\";
+interface SVGRProps {
+  desc?: string;
+  descId?: string;
+}
+
+const SvgComponent = ({
+  desc,
+  descId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
 exports[`plugin typescript with "expandProps" add props 1`] = `
 "import * as React from \\"react\\";
 import { SVGProps } from \\"react\\";
@@ -423,7 +505,28 @@ const ForwardRef = forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
 
-exports[`plugin typescript with "titleProp" adds "titleProp" and "titleId" prop 1`] = `
+exports[`plugin typescript with "titleProp" "descProp" and "expandProps" adds "title", "titleId", "desc", "descId" props and expands props 1`] = `
+"import * as React from \\"react\\";
+import { SVGProps } from \\"react\\";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+  desc?: string;
+  descId?: string;
+}
+
+const SvgComponent = ({
+  title,
+  titleId,
+  desc,
+  descId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
+exports[`plugin typescript with "titleProp" adds "title" and "titleId" prop 1`] = `
 "import * as React from \\"react\\";
 interface SVGRProps {
   title?: string;
@@ -438,7 +541,26 @@ const SvgComponent = ({
 export default SvgComponent;"
 `;
 
-exports[`plugin typescript with "titleProp" and "expandProps" adds "titleProp", "titleId" props and expands props 1`] = `
+exports[`plugin typescript with "titleProp" and "descProp" adds "title", "titleId", "desc", and "descId prop 1`] = `
+"import * as React from \\"react\\";
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+  desc?: string;
+  descId?: string;
+}
+
+const SvgComponent = ({
+  title,
+  titleId,
+  desc,
+  descId
+}: SVGRProps) => <svg><g /></svg>;
+
+export default SvgComponent;"
+`;
+
+exports[`plugin typescript with "titleProp" and "expandProps" adds "title", "titleId" props and expands props 1`] = `
 "import * as React from \\"react\\";
 import { SVGProps } from \\"react\\";
 interface SVGRProps {

--- a/packages/babel-plugin-transform-svg-component/src/index.test.ts
+++ b/packages/babel-plugin-transform-svg-component/src/index.test.ts
@@ -57,7 +57,7 @@ describe('plugin', () => {
     })
 
     describe('with "titleProp"', () => {
-      it('adds "titleProp" and "titleId" prop', () => {
+      it('adds "title" and "titleId" prop', () => {
         const { code } = testPlugin(language)('<svg><g /></svg>', {
           titleProp: true,
         })
@@ -66,11 +66,53 @@ describe('plugin', () => {
     })
 
     describe('with "titleProp" and "expandProps"', () => {
-      it('adds "titleProp", "titleId" props and expands props', () => {
+      it('adds "title", "titleId" props and expands props', () => {
         const { code } = testPlugin(language)('<svg><g /></svg>', {
           ...defaultOptions,
           expandProps: true,
           titleProp: true,
+        })
+        expect(code).toMatchSnapshot()
+      })
+    })
+
+    describe('with "descProp"', () => {
+      it('adds "desc" and "descId" prop', () => {
+        const { code } = testPlugin(language)('<svg><g /></svg>', {
+          descProp: true,
+        })
+        expect(code).toMatchSnapshot()
+      })
+    })
+
+    describe('with "descProp" and "expandProps"', () => {
+      it('adds "desc", "descId" props and expands props', () => {
+        const { code } = testPlugin(language)('<svg><g /></svg>', {
+          ...defaultOptions,
+          expandProps: true,
+          descProp: true,
+        })
+        expect(code).toMatchSnapshot()
+      })
+    })
+
+    describe('with "titleProp" and "descProp"', () => {
+      it('adds "title", "titleId", "desc", and "descId prop', () => {
+        const { code } = testPlugin(language)('<svg><g /></svg>', {
+          titleProp: true,
+          descProp: true,
+        })
+        expect(code).toMatchSnapshot()
+      })
+    })
+
+    describe('with "titleProp" "descProp" and "expandProps"', () => {
+      it('adds "title", "titleId", "desc", "descId" props and expands props', () => {
+        const { code } = testPlugin(language)('<svg><g /></svg>', {
+          ...defaultOptions,
+          expandProps: true,
+          titleProp: true,
+          descProp: true,
         })
         expect(code).toMatchSnapshot()
       })

--- a/packages/babel-plugin-transform-svg-component/src/types.ts
+++ b/packages/babel-plugin-transform-svg-component/src/types.ts
@@ -35,6 +35,7 @@ export interface JSXRuntimeImport {
 export interface Options {
   typescript?: boolean
   titleProp?: boolean
+  descProp?: boolean
   expandProps?: boolean | 'start' | 'end'
   ref?: boolean
   template?: Template

--- a/packages/babel-plugin-transform-svg-component/src/variables.ts
+++ b/packages/babel-plugin-transform-svg-component/src/variables.ts
@@ -122,21 +122,70 @@ export const getVariables = ({
     )
   }
 
-  if (opts.titleProp) {
-    const prop = t.objectPattern([
-      t.objectProperty(
-        t.identifier('title'),
-        t.identifier('title'),
-        false,
-        true,
-      ),
-      t.objectProperty(
-        t.identifier('titleId'),
-        t.identifier('titleId'),
-        false,
-        true,
-      ),
-    ])
+  if (opts.titleProp || opts.descProp) {
+    const properties = []
+    const propertySignatures = []
+    if (opts.titleProp) {
+      properties.push(
+        t.objectProperty(
+          t.identifier('title'),
+          t.identifier('title'),
+          false,
+          true,
+        ),
+        t.objectProperty(
+          t.identifier('titleId'),
+          t.identifier('titleId'),
+          false,
+          true,
+        ),
+      )
+
+      if (opts.typescript) {
+        propertySignatures.push(
+          tsOptionalPropertySignature(
+            t.identifier('title'),
+            t.tsTypeAnnotation(t.tsStringKeyword()),
+          ),
+          tsOptionalPropertySignature(
+            t.identifier('titleId'),
+            t.tsTypeAnnotation(t.tsStringKeyword()),
+          ),
+        )
+      }
+    }
+
+    if (opts.descProp) {
+      properties.push(
+        t.objectProperty(
+          t.identifier('desc'),
+          t.identifier('desc'),
+          false,
+          true,
+        ),
+        t.objectProperty(
+          t.identifier('descId'),
+          t.identifier('descId'),
+          false,
+          true,
+        ),
+      )
+
+      if (opts.typescript) {
+        propertySignatures.push(
+          tsOptionalPropertySignature(
+            t.identifier('desc'),
+            t.tsTypeAnnotation(t.tsStringKeyword()),
+          ),
+          tsOptionalPropertySignature(
+            t.identifier('descId'),
+            t.tsTypeAnnotation(t.tsStringKeyword()),
+          ),
+        )
+      }
+    }
+
+    const prop = t.objectPattern(properties)
     props.push(prop)
     if (opts.typescript) {
       interfaces.push(
@@ -144,16 +193,7 @@ export const getVariables = ({
           t.identifier('SVGRProps'),
           null,
           null,
-          t.tSInterfaceBody([
-            tsOptionalPropertySignature(
-              t.identifier('title'),
-              t.tsTypeAnnotation(t.tsStringKeyword()),
-            ),
-            tsOptionalPropertySignature(
-              t.identifier('titleId'),
-              t.tsTypeAnnotation(t.tsStringKeyword()),
-            ),
-          ]),
+          t.tSInterfaceBody(propertySignatures),
         ),
       )
       prop.typeAnnotation = t.tsTypeAnnotation(

--- a/packages/babel-plugin-transform-svg-component/src/variables.ts
+++ b/packages/babel-plugin-transform-svg-component/src/variables.ts
@@ -125,62 +125,39 @@ export const getVariables = ({
   if (opts.titleProp || opts.descProp) {
     const properties = []
     const propertySignatures = []
-    if (opts.titleProp) {
-      properties.push(
-        t.objectProperty(
-          t.identifier('title'),
-          t.identifier('title'),
-          false,
-          true,
-        ),
-        t.objectProperty(
-          t.identifier('titleId'),
-          t.identifier('titleId'),
-          false,
-          true,
-        ),
+    const createProperty = (attr: string) => {
+      return t.objectProperty(
+        t.identifier(attr),
+        t.identifier(attr),
+        false,
+        true,
       )
+    }
+    const createSignature = (attr: string) => {
+      return tsOptionalPropertySignature(
+        t.identifier(attr),
+        t.tsTypeAnnotation(t.tsStringKeyword()),
+      )
+    }
+
+    if (opts.titleProp) {
+      properties.push(createProperty('title'), createProperty('titleId'))
 
       if (opts.typescript) {
         propertySignatures.push(
-          tsOptionalPropertySignature(
-            t.identifier('title'),
-            t.tsTypeAnnotation(t.tsStringKeyword()),
-          ),
-          tsOptionalPropertySignature(
-            t.identifier('titleId'),
-            t.tsTypeAnnotation(t.tsStringKeyword()),
-          ),
+          createSignature('title'),
+          createSignature('titleId'),
         )
       }
     }
 
     if (opts.descProp) {
-      properties.push(
-        t.objectProperty(
-          t.identifier('desc'),
-          t.identifier('desc'),
-          false,
-          true,
-        ),
-        t.objectProperty(
-          t.identifier('descId'),
-          t.identifier('descId'),
-          false,
-          true,
-        ),
-      )
+      properties.push(createProperty('desc'), createProperty('descId'))
 
       if (opts.typescript) {
         propertySignatures.push(
-          tsOptionalPropertySignature(
-            t.identifier('desc'),
-            t.tsTypeAnnotation(t.tsStringKeyword()),
-          ),
-          tsOptionalPropertySignature(
-            t.identifier('descId'),
-            t.tsTypeAnnotation(t.tsStringKeyword()),
-          ),
+          createSignature('desc'),
+          createSignature('descId'),
         )
       }
     }

--- a/packages/babel-preset/src/index.test.ts
+++ b/packages/babel-preset/src/index.test.ts
@@ -83,6 +83,55 @@ describe('preset', () => {
     `)
   })
 
+  it('handles descProp', () => {
+    expect(
+      testPreset('<svg></svg>', {
+        descProp: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      "import * as React from \\"react\\";
+
+      const SvgComponent = ({
+        desc,
+        descId
+      }) => <svg aria-describedby={descId}>{desc ? <desc id={descId}>{desc}</desc> : null}</svg>;
+
+      export default SvgComponent;"
+    `)
+  })
+  it('handles descProp and fallback on existing desc', () => {
+    // testing when existing desc has string as chilren
+    expect(
+      testPreset(`<svg><desc>Hello</desc></svg>`, {
+        descProp: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      "import * as React from \\"react\\";
+
+      const SvgComponent = ({
+        desc,
+        descId
+      }) => <svg aria-describedby={descId}>{desc === undefined ? <desc id={descId}>Hello</desc> : desc ? <desc id={descId}>{desc}</desc> : null}</svg>;
+
+      export default SvgComponent;"
+    `)
+    // testing when existing desc has JSXExpression as children
+    expect(
+      testPreset(`<svg><desc>{"Hello"}</desc></svg>`, {
+        descProp: true,
+      }),
+    ).toMatchInlineSnapshot(`
+      "import * as React from \\"react\\";
+
+      const SvgComponent = ({
+        desc,
+        descId
+      }) => <svg aria-describedby={descId}>{desc === undefined ? <desc id={descId}>{\\"Hello\\"}</desc> : desc ? <desc id={descId}>{desc}</desc> : null}</svg>;
+
+      export default SvgComponent;"
+    `)
+  })
+
   it('handles replaceAttrValues', () => {
     expect(
       testPreset('<svg a="#000" b="#fff" />', {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -143,7 +143,7 @@ const plugin = (_: ConfigAPI, opts: Options) => {
   }
 
   if (opts.descProp) {
-    plugins.push(() => svgDynamicTitle('desc'))
+    plugins.push(svgDynamicTitle, { tag: 'desc' })
   }
 
   if (opts.native) {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -139,7 +139,7 @@ const plugin = (_: ConfigAPI, opts: Options) => {
   }
 
   if (opts.titleProp) {
-    plugins.push(() => svgDynamicTitle('title'))
+    plugins.push(svgDynamicTitle)
   }
 
   if (opts.descProp) {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -127,7 +127,7 @@ const plugin = (_: ConfigAPI, opts: Options) => {
   }
 
   if (opts.titleProp) {
-    plugins.push(svgDynamicTitle)
+    plugins.push(() => svgDynamicTitle('title'))
   }
 
   if (opts.native) {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -139,11 +139,11 @@ const plugin = (_: ConfigAPI, opts: Options) => {
   }
 
   if (opts.titleProp) {
-    plugins.push(svgDynamicTitle)
+    plugins.push([svgDynamicTitle, { tag: 'title' }])
   }
 
   if (opts.descProp) {
-    plugins.push(svgDynamicTitle, { tag: 'desc' })
+    plugins.push([svgDynamicTitle, { tag: 'desc' }])
   }
 
   if (opts.native) {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -18,6 +18,7 @@ import transformSvgComponent, {
 export interface Options extends TransformOptions {
   ref?: boolean
   titleProp?: boolean
+  descProp?: boolean
   expandProps?: boolean | 'start' | 'end'
   dimensions?: boolean
   icon?: boolean | string | number
@@ -76,6 +77,17 @@ const plugin = (_: ConfigAPI, opts: Options) => {
     ]
   }
 
+  if (opts.descProp) {
+    toAddAttributes = [
+      ...toAddAttributes,
+      {
+        name: 'aria-describedby',
+        value: 'descId',
+        literal: true,
+      },
+    ]
+  }
+
   if (opts.expandProps) {
     toAddAttributes = [
       ...toAddAttributes,
@@ -128,6 +140,10 @@ const plugin = (_: ConfigAPI, opts: Options) => {
 
   if (opts.titleProp) {
     plugins.push(() => svgDynamicTitle('title'))
+  }
+
+  if (opts.descProp) {
+    plugins.push(() => svgDynamicTitle('desc'))
   }
 
   if (opts.native) {

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -139,7 +139,7 @@ const plugin = (_: ConfigAPI, opts: Options) => {
   }
 
   if (opts.titleProp) {
-    plugins.push([svgDynamicTitle, { tag: 'title' }])
+    plugins.push(svgDynamicTitle)
   }
 
   if (opts.descProp) {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,7 @@ Options:
   --index-template <file>          specify a custom index.js template to use
   --no-index                       disable index file generation
   --title-prop                     create a title element linked with props
+  --desc-prop                      create a desc element linked with props
   --prettier-config <fileOrJson>   Prettier config
   --no-prettier                    disable Prettier
   --svgo-config <fileOrJson>       SVGO config

--- a/packages/cli/src/__snapshots__/index.test.ts.snap
+++ b/packages/cli/src/__snapshots__/index.test.ts.snap
@@ -155,6 +155,27 @@ export default SvgFile
 "
 `;
 
+exports[`cli should support various args: --desc-prop 1`] = `
+"import * as React from 'react'
+
+const SvgFile = ({ desc, descId, ...props }) => (
+  <svg
+    width={48}
+    height={1}
+    xmlns=\\"http://www.w3.org/2000/svg\\"
+    aria-describedby={descId}
+    {...props}
+  >
+    {desc ? <desc id={descId}>{desc}</desc> : null}
+    <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
+  </svg>
+)
+
+export default SvgFile
+
+"
+`;
+
 exports[`cli should support various args: --expand-props none 1`] = `
 "import * as React from 'react'
 
@@ -480,6 +501,37 @@ const SvgFile = ({ title, titleId, ...props }) => (
 )
 
 export default SvgFile
+
+"
+`;
+
+exports[`cli should support various args: --typescript --ref --desc-prop 1`] = `
+"import * as React from 'react'
+import { SVGProps, Ref, forwardRef } from 'react'
+interface SVGRProps {
+  desc?: string;
+  descId?: string;
+}
+
+const SvgFile = (
+  { desc, descId, ...props }: SVGProps<SVGSVGElement> & SVGRProps,
+  ref: Ref<SVGSVGElement>,
+) => (
+  <svg
+    width={48}
+    height={1}
+    xmlns=\\"http://www.w3.org/2000/svg\\"
+    ref={ref}
+    aria-describedby={descId}
+    {...props}
+  >
+    {desc ? <desc id={descId}>{desc}</desc> : null}
+    <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
+  </svg>
+)
+
+const ForwardRef = forwardRef(SvgFile)
+export default ForwardRef
 
 "
 `;

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -131,9 +131,11 @@ describe('cli', () => {
     ['--no-svgo'],
     ['--no-prettier'],
     ['--title-prop'],
+    ['--desc-prop'],
     ['--typescript'],
     ['--typescript --ref'],
     ['--typescript --ref --title-prop'],
+    ['--typescript --ref --desc-prop'],
   ])(
     'should support various args',
     async (args) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -146,6 +146,7 @@ program
   )
   .option('--no-index', 'disable index file generation')
   .option('--title-prop', 'create a title element linked with props')
+  .option('--desc-prop', 'create a desc element linked with props')
   .option(
     '--prettier-config <fileOrJson>',
     'Prettier config',

--- a/packages/core/src/__snapshots__/config.test.ts.snap
+++ b/packages/core/src/__snapshots__/config.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`svgo async #loadConfig [async] should load config using filePath 1`] = `
 Object {
+  "descProp": false,
   "dimensions": true,
   "expandProps": "end",
   "exportType": "default",
@@ -32,6 +33,7 @@ Object {
 
 exports[`svgo async #loadConfig [async] should not load config with "runtimeConfig: false 1`] = `
 Object {
+  "descProp": false,
   "dimensions": true,
   "expandProps": "end",
   "exportType": "default",
@@ -63,6 +65,7 @@ Object {
 
 exports[`svgo async #loadConfig [async] should use default config without state.filePath 1`] = `
 Object {
+  "descProp": false,
   "dimensions": false,
   "expandProps": "end",
   "exportType": "default",
@@ -87,6 +90,7 @@ Object {
 
 exports[`svgo async #loadConfig [async] should work with custom config path 1`] = `
 Object {
+  "descProp": false,
   "dimensions": true,
   "expandProps": "end",
   "exportType": "default",
@@ -117,6 +121,7 @@ Object {
 
 exports[`svgo sync #loadConfig [sync] should load config using filePath 1`] = `
 Object {
+  "descProp": false,
   "dimensions": true,
   "expandProps": "end",
   "exportType": "default",
@@ -147,6 +152,7 @@ Object {
 
 exports[`svgo sync #loadConfig [sync] should not load config with "runtimeConfig: false 1`] = `
 Object {
+  "descProp": false,
   "dimensions": true,
   "expandProps": "end",
   "exportType": "default",
@@ -178,6 +184,7 @@ Object {
 
 exports[`svgo sync #loadConfig [sync] should use default config without state.filePath 1`] = `
 Object {
+  "descProp": false,
   "dimensions": false,
   "expandProps": "end",
   "exportType": "default",
@@ -202,6 +209,7 @@ Object {
 
 exports[`svgo sync #loadConfig [sync] should work with custom config path 1`] = `
 Object {
+  "descProp": false,
   "dimensions": true,
   "expandProps": "end",
   "exportType": "default",

--- a/packages/core/src/__snapshots__/transform.test.ts.snap
+++ b/packages/core/src/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`convert config accepts options {"descProp":true} 1`] = `
+"import * as React from 'react'
+
+const SvgComponent = ({ desc, descId, ...props }) => (
+  <svg
+    width={88}
+    height={88}
+    xmlns=\\"http://www.w3.org/2000/svg\\"
+    aria-describedby={descId}
+    {...props}
+  >
+    {desc ? <desc id={descId}>{desc}</desc> : null}
+    <g
+      stroke=\\"#063855\\"
+      strokeWidth={2}
+      fill=\\"none\\"
+      fillRule=\\"evenodd\\"
+      strokeLinecap=\\"square\\"
+    >
+      <path d=\\"M51 37 37 51M51 51 37 37\\" />
+    </g>
+  </svg>
+)
+
+export default SvgComponent
+"
+`;
+
 exports[`convert config accepts options {"dimensions":false} 1`] = `
 "import * as React from 'react'
 
@@ -486,6 +514,28 @@ exports[`convert config accepts options {} 1`] = `
 "const noop = () => null
 
 export default noop
+"
+`;
+
+exports[`convert config descProp: without desc added 1`] = `
+"import * as React from 'react'
+
+const SvgComponent = ({ desc, descId, ...props }) => (
+  <svg
+    width={0}
+    height={0}
+    style={{
+      position: 'absolute',
+    }}
+    aria-describedby={descId}
+    {...props}
+  >
+    {desc ? <desc id={descId}>{desc}</desc> : null}
+    <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+  </svg>
+)
+
+export default SvgComponent
 "
 `;
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,6 +9,7 @@ import type { State } from './state'
 export interface Config {
   ref?: boolean
   titleProp?: boolean
+  descProp?: boolean
   expandProps?: boolean | 'start' | 'end'
   dimensions?: boolean
   icon?: boolean | string | number
@@ -59,6 +60,7 @@ export const DEFAULT_CONFIG: Config = {
   template: undefined,
   index: false,
   titleProp: false,
+  descProp: false,
   runtimeConfig: true,
   namedExport: 'ReactComponent',
   exportType: 'default',

--- a/packages/core/src/transform.test.ts
+++ b/packages/core/src/transform.test.ts
@@ -317,6 +317,7 @@ describe('convert', () => {
           tpl`const noop = () => null; export default noop;`,
       },
       { titleProp: true },
+      { descProp: true },
       { memo: true },
       {
         namedExport: 'Component',
@@ -338,6 +339,17 @@ describe('convert', () => {
 `
       expect(
         await convertWithAllPlugins(svg, { titleProp: true }),
+      ).toMatchSnapshot()
+    })
+
+    it('descProp: without desc added', async () => {
+      const svg = `
+      <svg width="0" height="0" style="position:absolute">
+    <path d="M0 0h24v24H0z" fill="none" />
+</svg>
+`
+      expect(
+        await convertWithAllPlugins(svg, { descProp: true }),
       ).toMatchSnapshot()
     })
   })

--- a/packages/plugin-jsx/src/index.ts
+++ b/packages/plugin-jsx/src/index.ts
@@ -38,6 +38,7 @@ const jsxPlugin: Plugin = (code, config, state) => {
   const svgPresetOptions: SvgrPresetOptions = {
     ref: config.ref,
     titleProp: config.titleProp,
+    descProp: config.descProp,
     expandProps: config.expandProps,
     dimensions: config.dimensions,
     icon: config.icon,

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -178,6 +178,14 @@ Add title tag via title property. If titleProp is set to true and no title is pr
 | ------- | -------------- | -------------------- |
 | `false` | `--title-prop` | `titleProp: boolean` |
 
+## Description
+
+Add desc tag via title property. If descProp is set to true and no description is provided (`desc={undefined}`) at render time, this will fallback to an existing desc element in the svg if exists.
+
+| Default | CLI Override  | API Override        |
+| ------- | ------------- | ------------------- |
+| `false` | `--desc-prop` | `descProp: boolean` |
+
 ## Template
 
 Specify a template file (CLI) or a template function (API) to use. For an example of template, see [the default one](https://github.com/gregberge/svgr/blob/main/packages/babel-plugin-transform-svg-component/src/defaultTemplate.ts).

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -180,7 +180,7 @@ Add title tag via title property. If titleProp is set to true and no title is pr
 
 ## Description
 
-Add desc tag via title property. If descProp is set to true and no description is provided (`desc={undefined}`) at render time, this will fallback to an existing desc element in the svg if exists.
+Add desc tag via desc property. If descProp is set to true and no description is provided (`desc={undefined}`) at render time, this will fallback to an existing desc element in the svg if exists.
 
 | Default | CLI Override  | API Override        |
 | ------- | ------------- | ------------------- |

--- a/website/src/components/playground/config/settings.js
+++ b/website/src/components/playground/config/settings.js
@@ -68,6 +68,13 @@ export const settings = [
     default: false,
   },
   {
+    label: 'Desc prop',
+    name: 'descProp',
+    type: 'boolean',
+    group: 'global',
+    default: false,
+  },
+  {
     label: 'Expand props',
     name: 'expandProps',
     type: 'enum',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fixes #714 

- Updated README.md and src files in `babel-plugin-svg-dynamic-title` to add a descProp
  - the plugin now takes in a `tag` option indicating the attribute/element to add to the svg ('title' for title, or 'desc' for desc)
- Updated `babel-plugin-transform-svg-component` to add additional desc and descId attributes to the svg if descProp is true
- Updated `babel-preset` to add the `aria-describedby` attribute
- Added descProp to various options, cli-config, etc.
- Updated documentation to include a Description section

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Simply `npm run test`! Existing tests have been slightly modified. New tests have been added to test the new feature.
