### PR TITLE
Add package.json to the exports

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,7 +3,10 @@
   "description": "SVGR webpack loader.",
   "version": "6.2.1",
   "main": "./dist/index.js",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "typings": "./dist/index.d.ts",
   "repository": "https://github.com/gregberge/svgr/tree/master/packages/webpack",
   "author": "Greg Bergé <berge.greg@gmail.com>",


### PR DESCRIPTION
## Summary

The React Native build tools search through all dependencies and parse the package.json from each. When the package.json is not included in a dependencies `exports`, the build fails, and so currently svgr/webpack cannot be used with React Native. 
There's thread with a feature request for Node to have special treatment for package.json, but the Node team have stated this isn't likely to happen: https://github.com/nodejs/node/issues/33460
There's an open PR for the React Native tools to add an attempt at a fallback to deal with this, but it's more of a workaround than an actual fix: https://github.com/react-native-community/cli/pull/1648
The actual fix requires any used dependencies to either exclude the `exports` section in their package.json, or to list the package.json as an export. This also fixes #742 

## Test plan

- Build the project (`npm run build`).
- Include the project as a dependency in another project.
- Require the package.json: `require("@svgr/webpack/package.json");`

Without explicitly specifying the package.json in the exports, the `require` fails with: `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports"`.
