### PR TITLE
Fix exports

### DIFF
--- a/packages/babel-plugin-add-jsx-attribute/package.json
+++ b/packages/babel-plugin-add-jsx-attribute/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-remove-jsx-attribute/package.json
+++ b/packages/babel-plugin-remove-jsx-attribute/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-remove-jsx-empty-expression/package.json
+++ b/packages/babel-plugin-remove-jsx-empty-expression/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-replace-jsx-attribute-value/package.json
+++ b/packages/babel-plugin-replace-jsx-attribute-value/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-svg-dynamic-title/package.json
+++ b/packages/babel-plugin-svg-dynamic-title/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-svg-em-dimensions/package.json
+++ b/packages/babel-plugin-svg-em-dimensions/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-transform-react-native-svg/package.json
+++ b/packages/babel-plugin-transform-react-native-svg/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-plugin-transform-svg-component/package.json
+++ b/packages/babel-plugin-transform-svg-component/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/hast-util-to-babel-ast/package.json
+++ b/packages/hast-util-to-babel-ast/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/plugin-jsx/package.json
+++ b/packages/plugin-jsx/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/plugin-prettier/package.json
+++ b/packages/plugin-prettier/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/plugin-svgo/package.json
+++ b/packages/plugin-svgo/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
The recent exports change broke ESM imports. Attempting to `import '@svgr/core'` results in

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /code/node_modules/@svgr/core/package.json imported from ...
```

According to https://nodejs.org/api/packages.html#conditional-exports, a `default` key should be used here instead of `require` since it will work for both CJS and ESM. I made this change locally and verified ESM imports worked again.