### PR TITLE
[CUSTOM-TEMPLATE] write test prove failing scenario

### DIFF
--- a/__fixtures__/custom-template.js
+++ b/__fixtures__/custom-template.js
@@ -1,0 +1,15 @@
+function template(
+    { imports, componentName, props, jsx, exports },
+    { tpl }
+  ) {
+    return tpl`
+  // THIS IS A COMMENT
+  ${imports}
+  export function ${componentName}(${props}) {
+    return ${jsx};
+  }
+  `
+  }
+
+
+  module.exports = template

--- a/packages/cli/src/__snapshots__/index.test.ts.snap
+++ b/packages/cli/src/__snapshots__/index.test.ts.snap
@@ -89,6 +89,19 @@ export default SvgFile
 "
 `;
 
+exports[`cli should support --template in cli 1`] = `
+// THIS IS A COMMENT
+"import * as React from 'react'
+export function SvgFile(props) {
+  return (
+    <svg width={48} height={1} xmlns=\\"http://www.w3.org/2000/svg\\" {...props}>
+      <path d=\\"M0 0h48v1H0z\\" fill=\\"#063855\\" fillRule=\\"evenodd\\" />
+    </svg>
+  )
+}
+"
+`;
+
 exports[`cli should support custom file extension 1`] = `
 Array [
   "File.ts",

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -222,6 +222,17 @@ describe('cli', () => {
     expect(content).toMatchSnapshot()
   })
 
+  it('should support --template in cli', async () => {
+    const inDir = '__fixtures__/simple'
+    const outDir = `__fixtures_build__/custom-template-arg`
+    await del(outDir)
+    await cli(
+      `${inDir} --out-dir=${outDir} --template=__fixtures__/custom-template.js`,
+    )
+    const content = await fs.readFile(path.join(outDir, 'File.js'), 'utf-8')
+    expect(content).toMatchSnapshot()
+  })
+
   it('should support --no-index', async () => {
     const inDir = '__fixtures__/simple'
     const outDir = `__fixtures_build__/no-index-case`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Cannot add comments to a custom template even though it looks like you should. The feature was added recently (#661) so it should work, but from my testing locally and this draft PR the test fails. 

The scenario being, you want to add a comment to top of a custom template, to indicate that it's generated and not to edit. This is especially handy if you're adding the generated icons to source.  

## Test plan

* Added a test of the failing scenario but don't have a fix yet. 

NOTE: I've edited the snapshot to be what I expect, so the test is currently failing.  
