### PR TITLE
docs: update vite plugin recommendation

### DIFF
--- a/website/pages/docs/ecosystem.mdx
+++ b/website/pages/docs/ecosystem.mdx
@@ -35,7 +35,7 @@ This is an incomplete list of awesome things built with SVGR.
 - [chin-plugin-svgr](https://www.npmjs.com/package/chin-plugin-svgr) - SVGR plugin for [chin](https://github.com/chinjs/chin)
 - [@nice-js/svgr-loader](https://www.npmjs.com/package/@nice-js/svgr-loader) - SVGR loader for Nice.js
 - [bs-svgr](https://www.npmjs.com/package/bs-svgr) - SVGR plugin for BuckleScript (Reason)
-- [vite-plugin-svgr](https://github.com/lucsky/vite-plugin-svgr) - SVGR loader for [Vite](https://vitejs.dev/)
+- [vite-plugin-svgr](https://github.com/pd4d10/vite-plugin-svgr) - SVGR loader for [Vite](https://vitejs.dev/)
 - [SVGR for Figma](https://www.figma.com/community/plugin/749818562498396194/SVG-to-JSX)
 - [esbuild-plugin-svgr](https://github.com/kazijawad/esbuild-plugin-svgr)
 


### PR DESCRIPTION
## Summary

Updated the Vite plugin recommendation as the project listed in the current docs has been deprecated, see here: https://github.com/lucsky/vite-plugin-svgr/issues/5

## Test plan

None. This is a simple documentation change.
