### PR TITLE
Support spaces in source file names

### DIFF
--- a/packages/core/src/state.test.ts
+++ b/packages/core/src/state.test.ts
@@ -24,6 +24,11 @@ describe('state', () => {
         filePath: 'a&b~c-d_e.svg',
         componentName: 'SvgAbcDE',
       })
+      expect(expandState({ filePath: 'Arrow up.svg' })).toEqual({
+        filePath: 'Arrow up.svg',
+        componentName: 'SvgArrowUp',
+      })
+
     })
   })
 })

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -13,7 +13,7 @@ export interface State {
   }
 }
 
-const VALID_CHAR_REGEX = /[^a-zA-Z0-9_-]/g
+const VALID_CHAR_REGEX = /[^a-zA-Z0-9 _-]/g
 
 const getComponentName = (filePath?: string): string => {
   if (!filePath) return 'SvgComponent'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Currently source file names that have spaces in them are not converted to component names the same way as the file names, e.g. from `Arrow up.svg` the component name will be `SvgArrowup` and the file name will be `SvgArrowUp.tsx`.

The PR fixes this discrepancy by *not* removing spaces from the file names before converting them to PascalCase.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added a test case.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
