### PR TITLE
fix(deps): add babel-preset to core dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21075,7 +21075,7 @@
     },
     "packages/babel-plugin-add-jsx-attribute": {
       "name": "@svgr/babel-plugin-add-jsx-attribute",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21090,7 +21090,7 @@
     },
     "packages/babel-plugin-remove-jsx-attribute": {
       "name": "@svgr/babel-plugin-remove-jsx-attribute",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21105,7 +21105,7 @@
     },
     "packages/babel-plugin-remove-jsx-empty-expression": {
       "name": "@svgr/babel-plugin-remove-jsx-empty-expression",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21120,7 +21120,7 @@
     },
     "packages/babel-plugin-replace-jsx-attribute-value": {
       "name": "@svgr/babel-plugin-replace-jsx-attribute-value",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21135,7 +21135,7 @@
     },
     "packages/babel-plugin-svg-dynamic-title": {
       "name": "@svgr/babel-plugin-svg-dynamic-title",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21150,7 +21150,7 @@
     },
     "packages/babel-plugin-svg-em-dimensions": {
       "name": "@svgr/babel-plugin-svg-em-dimensions",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21165,7 +21165,7 @@
     },
     "packages/babel-plugin-transform-react-native-svg": {
       "name": "@svgr/babel-plugin-transform-react-native-svg",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21180,7 +21180,7 @@
     },
     "packages/babel-plugin-transform-svg-component": {
       "name": "@svgr/babel-plugin-transform-svg-component",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -21195,17 +21195,17 @@
     },
     "packages/babel-preset": {
       "name": "@svgr/babel-preset",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": "^6.3.0",
-        "@svgr/babel-plugin-remove-jsx-attribute": "^6.3.0",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "^6.3.0",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.3.0",
-        "@svgr/babel-plugin-svg-dynamic-title": "^6.3.0",
-        "@svgr/babel-plugin-svg-em-dimensions": "^6.3.0",
-        "@svgr/babel-plugin-transform-react-native-svg": "^6.3.0",
-        "@svgr/babel-plugin-transform-svg-component": "^6.3.0"
+        "@svgr/babel-plugin-add-jsx-attribute": "^6.3.1",
+        "@svgr/babel-plugin-remove-jsx-attribute": "^6.3.1",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "^6.3.1",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.3.1",
+        "@svgr/babel-plugin-svg-dynamic-title": "^6.3.1",
+        "@svgr/babel-plugin-svg-em-dimensions": "^6.3.1",
+        "@svgr/babel-plugin-transform-react-native-svg": "^6.3.1",
+        "@svgr/babel-plugin-transform-svg-component": "^6.3.1"
       },
       "engines": {
         "node": ">=10"
@@ -21220,13 +21220,13 @@
     },
     "packages/cli": {
       "name": "@svgr/cli",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
-        "@svgr/core": "^6.3.0",
-        "@svgr/plugin-jsx": "^6.3.0",
-        "@svgr/plugin-prettier": "^6.3.0",
-        "@svgr/plugin-svgo": "^6.3.0",
+        "@svgr/core": "^6.3.1",
+        "@svgr/plugin-jsx": "^6.3.1",
+        "@svgr/plugin-prettier": "^6.3.1",
+        "@svgr/plugin-svgo": "^6.3.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
@@ -21314,10 +21314,10 @@
     },
     "packages/core": {
       "name": "@svgr/core",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
-        "@svgr/plugin-jsx": "^6.3.0",
+        "@svgr/plugin-jsx": "^6.3.1",
         "camelcase": "^6.2.0",
         "cosmiconfig": "^7.0.1"
       },
@@ -21334,7 +21334,7 @@
     },
     "packages/hast-util-to-babel-ast": {
       "name": "@svgr/hast-util-to-babel-ast",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.4",
@@ -21353,12 +21353,12 @@
     },
     "packages/plugin-jsx": {
       "name": "@svgr/plugin-jsx",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.5",
-        "@svgr/babel-preset": "^6.3.0",
-        "@svgr/hast-util-to-babel-ast": "^6.3.0",
+        "@svgr/babel-preset": "^6.3.1",
+        "@svgr/hast-util-to-babel-ast": "^6.3.1",
         "svg-parser": "^2.0.4"
       },
       "engines": {
@@ -21374,7 +21374,7 @@
     },
     "packages/plugin-prettier": {
       "name": "@svgr/plugin-prettier",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -21393,7 +21393,7 @@
     },
     "packages/plugin-svgo": {
       "name": "@svgr/plugin-svgo",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "cosmiconfig": "^7.0.1",
@@ -21413,7 +21413,7 @@
     },
     "packages/rollup": {
       "name": "@svgr/rollup",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.5",
@@ -21422,9 +21422,9 @@
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
         "@rollup/pluginutils": "^4.2.1",
-        "@svgr/core": "^6.3.0",
-        "@svgr/plugin-jsx": "^6.3.0",
-        "@svgr/plugin-svgo": "^6.3.0"
+        "@svgr/core": "^6.3.1",
+        "@svgr/plugin-jsx": "^6.3.1",
+        "@svgr/plugin-svgo": "^6.3.1"
       },
       "devDependencies": {
         "rollup": "^2.75.6",
@@ -21458,7 +21458,7 @@
     },
     "packages/webpack": {
       "name": "@svgr/webpack",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.5",
@@ -21466,9 +21466,9 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
-        "@svgr/core": "^6.3.0",
-        "@svgr/plugin-jsx": "^6.3.0",
-        "@svgr/plugin-svgo": "^6.3.0"
+        "@svgr/core": "^6.3.1",
+        "@svgr/plugin-jsx": "^6.3.1",
+        "@svgr/plugin-svgo": "^6.3.1"
       },
       "devDependencies": {
         "babel-loader": "^8.2.5",
@@ -25483,23 +25483,23 @@
     "@svgr/babel-preset": {
       "version": "file:packages/babel-preset",
       "requires": {
-        "@svgr/babel-plugin-add-jsx-attribute": "^6.3.0",
-        "@svgr/babel-plugin-remove-jsx-attribute": "^6.3.0",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "^6.3.0",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.3.0",
-        "@svgr/babel-plugin-svg-dynamic-title": "^6.3.0",
-        "@svgr/babel-plugin-svg-em-dimensions": "^6.3.0",
-        "@svgr/babel-plugin-transform-react-native-svg": "^6.3.0",
-        "@svgr/babel-plugin-transform-svg-component": "^6.3.0"
+        "@svgr/babel-plugin-add-jsx-attribute": "^6.3.1",
+        "@svgr/babel-plugin-remove-jsx-attribute": "^6.3.1",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "^6.3.1",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.3.1",
+        "@svgr/babel-plugin-svg-dynamic-title": "^6.3.1",
+        "@svgr/babel-plugin-svg-em-dimensions": "^6.3.1",
+        "@svgr/babel-plugin-transform-react-native-svg": "^6.3.1",
+        "@svgr/babel-plugin-transform-svg-component": "^6.3.1"
       }
     },
     "@svgr/cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@svgr/core": "^6.3.0",
-        "@svgr/plugin-jsx": "^6.3.0",
-        "@svgr/plugin-prettier": "^6.3.0",
-        "@svgr/plugin-svgo": "^6.3.0",
+        "@svgr/core": "^6.3.1",
+        "@svgr/plugin-jsx": "^6.3.1",
+        "@svgr/plugin-prettier": "^6.3.1",
+        "@svgr/plugin-svgo": "^6.3.1",
         "@types/glob": "^7.2.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.2",
@@ -25557,7 +25557,7 @@
     "@svgr/core": {
       "version": "file:packages/core",
       "requires": {
-        "@svgr/plugin-jsx": "^6.3.0",
+        "@svgr/plugin-jsx": "^6.3.1",
         "@types/svgo": "^2.6.3",
         "camelcase": "^6.2.0",
         "cosmiconfig": "^7.0.1"
@@ -25581,8 +25581,8 @@
       "version": "file:packages/plugin-jsx",
       "requires": {
         "@babel/core": "^7.18.5",
-        "@svgr/babel-preset": "^6.3.0",
-        "@svgr/hast-util-to-babel-ast": "^6.3.0",
+        "@svgr/babel-preset": "^6.3.1",
+        "@svgr/hast-util-to-babel-ast": "^6.3.1",
         "svg-parser": "^2.0.4"
       }
     },
@@ -25610,9 +25610,9 @@
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
         "@rollup/pluginutils": "^4.2.1",
-        "@svgr/core": "^6.3.0",
-        "@svgr/plugin-jsx": "^6.3.0",
-        "@svgr/plugin-svgo": "^6.3.0",
+        "@svgr/core": "^6.3.1",
+        "@svgr/plugin-jsx": "^6.3.1",
+        "@svgr/plugin-svgo": "^6.3.1",
         "rollup": "^2.75.6",
         "rollup-plugin-image": "^1.0.2",
         "rollup-plugin-url": "^3.0.1"
@@ -25642,9 +25642,9 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
-        "@svgr/core": "^6.3.0",
-        "@svgr/plugin-jsx": "^6.3.0",
-        "@svgr/plugin-svgo": "^6.3.0",
+        "@svgr/core": "^6.3.1",
+        "@svgr/plugin-jsx": "^6.3.1",
+        "@svgr/plugin-svgo": "^6.3.1",
         "babel-loader": "^8.2.5",
         "memory-fs": "^0.5.0",
         "url-loader": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21317,6 +21317,7 @@
       "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
+        "@svgr/babel-preset": "^6.3.1",
         "@svgr/plugin-jsx": "^6.3.1",
         "camelcase": "^6.2.0",
         "cosmiconfig": "^7.0.1"
@@ -25557,6 +25558,7 @@
     "@svgr/core": {
       "version": "file:packages/core",
       "requires": {
+        "@svgr/babel-preset": "^6.3.1",
         "@svgr/plugin-jsx": "^6.3.1",
         "@types/svgo": "^2.6.3",
         "camelcase": "^6.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "prepublishOnly": "npm run reset && npm run build"
   },
   "dependencies": {
+    "@svgr/babel-preset": "^6.3.1",
     "@svgr/plugin-jsx": "^6.3.1",
     "camelcase": "^6.2.0",
     "cosmiconfig": "^7.0.1"


### PR DESCRIPTION
Fixes #781.

The 6.3.0 -> 6.3.1 changes were caused by just doing `npm install`.