### PR TITLE
Rename "master" to "main" in package.json repository fields

### DIFF
--- a/packages/babel-plugin-add-jsx-attribute/package.json
+++ b/packages/babel-plugin-add-jsx-attribute/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-add-jsx-attribute",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-add-jsx-attribute",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-remove-jsx-attribute/package.json
+++ b/packages/babel-plugin-remove-jsx-attribute/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-remove-jsx-attribute",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-remove-jsx-attribute",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-remove-jsx-empty-expression/package.json
+++ b/packages/babel-plugin-remove-jsx-empty-expression/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-remove-jsx-empty-expression",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-remove-jsx-empty-expression",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-replace-jsx-attribute-value/package.json
+++ b/packages/babel-plugin-replace-jsx-attribute-value/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-replace-jsx-attribute-value",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-replace-jsx-attribute-value",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-svg-dynamic-title/package.json
+++ b/packages/babel-plugin-svg-dynamic-title/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-svg-dynamic-title",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-svg-dynamic-title",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-svg-em-dimensions/package.json
+++ b/packages/babel-plugin-svg-em-dimensions/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-svg-em-dimensions",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-svg-em-dimensions",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-react-native-svg/package.json
+++ b/packages/babel-plugin-transform-react-native-svg/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-react-native-svg",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-transform-react-native-svg",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-transform-svg-component/package.json
+++ b/packages/babel-plugin-transform-svg-component/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-svg-component",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-plugin-transform-svg-component",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/babel-preset",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/babel-preset",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@svgr/cli",
   "description": "SVGR command line.",
   "version": "6.4.0",
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/cli",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/cli",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/core",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/core",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/hast-util-to-babel-ast/package.json
+++ b/packages/hast-util-to-babel-ast/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/hast-util-to-babel-ast",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/hast-util-to-babel-ast",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-jsx/package.json
+++ b/packages/plugin-jsx/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/plugin-jsx",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/plugin-jsx",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-prettier/package.json
+++ b/packages/plugin-prettier/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/plugin-prettier",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/plugin-prettier",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-svgo/package.json
+++ b/packages/plugin-svgo/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/plugin-svgo",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/plugin-svgo",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/rollup",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/rollup",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -11,7 +11,7 @@
     },
     "./package.json": "./package.json"
   },
-  "repository": "https://github.com/gregberge/svgr/tree/master/packages/webpack",
+  "repository": "https://github.com/gregberge/svgr/tree/main/packages/webpack",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

The "Repository" links on npmjs.com package pages are out of date; right now, following those links gives a redirect, "Branch master was renamed to main."
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

N/A (affects publishing only)