### PR TITLE
Fix Yarn peer dependency warning from @babel/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21317,6 +21317,7 @@
       "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
+        "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.4.0",
         "@svgr/plugin-jsx": "^6.4.0",
         "camelcase": "^6.2.0",
@@ -25558,6 +25559,7 @@
     "@svgr/core": {
       "version": "file:packages/core",
       "requires": {
+        "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.4.0",
         "@svgr/plugin-jsx": "^6.4.0",
         "@types/svgo": "^2.6.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "prepublishOnly": "npm run reset && npm run build"
   },
   "dependencies": {
+    "@babel/core": "^7.18.5",
     "@svgr/babel-preset": "^6.4.0",
     "@svgr/plugin-jsx": "^6.4.0",
     "camelcase": "^6.2.0",


### PR DESCRIPTION
## Summary

Installing @svgr/core with Yarn Modern (Yarn 2+) gives the following warning:

```
➤ YN0002: │ @svgr/core@npm:6.4.0 doesn't provide @babel/core (p0b84c), requested by @svgr/babel-preset
```

Fixes #785.

## Test plan

`npm run test` and `npm run lint` still pass.