### PR TITLE
Allow hyperapp compatibility via config file

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`plugin javascript #jsxRuntime allows to specify a custom "classic" jsxRuntime using "defaultSpecifier" 1`] = `
+"import h from "hyperapp-jsx-pragma";
+const SvgComponent = () => <svg><g /></svg>;
+export default SvgComponent;"
+`;
+
 exports[`plugin javascript #jsxRuntime allows to specify a custom "classic" jsxRuntime using "namespace" 1`] = `
 "import * as Preact from "preact";
 const SvgComponent = () => <svg><g /></svg>;
@@ -224,6 +230,12 @@ const SvgComponent = (_, ref) => <svg><g /></svg>;
 const ForwardRef = forwardRef(SvgComponent);
 const Memo = memo(ForwardRef);
 export default Memo;"
+`;
+
+exports[`plugin typescript #jsxRuntime allows to specify a custom "classic" jsxRuntime using "defaultSpecifier" 1`] = `
+"import h from "hyperapp-jsx-pragma";
+const SvgComponent = () => <svg><g /></svg>;
+export default SvgComponent;"
 `;
 
 exports[`plugin typescript #jsxRuntime allows to specify a custom "classic" jsxRuntime using "namespace" 1`] = `

--- a/packages/babel-plugin-transform-svg-component/src/index.test.ts
+++ b/packages/babel-plugin-transform-svg-component/src/index.test.ts
@@ -338,6 +338,14 @@ describe('plugin', () => {
         expect(code).toMatchSnapshot()
       })
 
+      it('allows to specify a custom "classic" jsxRuntime using "defaultSpecifier"', () => {
+        const { code } = testPlugin(language)('<svg><g /></svg>', {
+          jsxRuntime: 'classic',
+          jsxRuntimeImport: { defaultSpecifier: 'h', source: 'hyperapp-jsx-pragma' },
+        })
+        expect(code).toMatchSnapshot()
+      })
+
       it('throws with invalid configuration', () => {
         expect(() => {
           testPlugin(language)('<svg><g /></svg>', {
@@ -345,7 +353,7 @@ describe('plugin', () => {
             jsxRuntimeImport: { source: 'preact' },
           })
         }).toThrow(
-          'Specify either "namespace" or "specifiers" in "jsxRuntimeImport" option',
+          'Specify "namespace", "defaultSpecifier", or "specifiers" in "jsxRuntimeImport" option',
         )
       })
     })

--- a/packages/babel-plugin-transform-svg-component/src/types.ts
+++ b/packages/babel-plugin-transform-svg-component/src/types.ts
@@ -29,6 +29,7 @@ interface State {
 export interface JSXRuntimeImport {
   source: string
   namespace?: string
+  defaultSpecifier?: string
   specifiers?: string[]
 }
 

--- a/packages/babel-plugin-transform-svg-component/src/variables.ts
+++ b/packages/babel-plugin-transform-svg-component/src/variables.ts
@@ -69,13 +69,17 @@ const getJsxRuntimeImport = (cfg: JSXRuntimeImport) => {
   const specifiers = (() => {
     if (cfg.namespace)
       return [t.importNamespaceSpecifier(t.identifier(cfg.namespace))]
+    if (cfg.defaultSpecifier) {
+      const identifier = t.identifier(cfg.defaultSpecifier)
+      return [t.importDefaultSpecifier(identifier)]
+    }
     if (cfg.specifiers)
       return cfg.specifiers.map((specifier) => {
         const identifier = t.identifier(specifier)
         return t.importSpecifier(identifier, identifier)
       })
     throw new Error(
-      `Specify either "namespace" or "specifiers" in "jsxRuntimeImport" option`,
+      `Specify "namespace", "defaultSpecifier", or "specifiers" in "jsxRuntimeImport" option`,
     )
   })()
   return t.importDeclaration(specifiers, t.stringLiteral(cfg.source))

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -36,6 +36,7 @@ export interface Config {
     source: string
     namespace?: string
     specifiers?: string[]
+    defaultSpecifier?: string
   }
 
   // CLI only

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -32,6 +32,11 @@ export interface Config {
   exportType?: 'named' | 'default'
   namedExport?: string
   jsxRuntime?: 'classic' | 'classic-preact' | 'automatic'
+  jsxRuntimeImport?: {
+    source: string
+    namespace?: string
+    specifiers?: string[]
+  }
 
   // CLI only
   index?: boolean

--- a/packages/plugin-jsx/src/index.ts
+++ b/packages/plugin-jsx/src/index.ts
@@ -7,6 +7,12 @@ import svgrBabelPreset, {
 import type { Plugin, Config } from '@svgr/core'
 
 const getJsxRuntimeOptions = (config: Config): Partial<SvgrPresetOptions> => {
+  if (config.jsxRuntimeImport) {
+    return {
+      importSource: config.jsxRuntimeImport.source,
+      jsxRuntimeImport: config.jsxRuntimeImport,
+    }
+  }
   switch (config.jsxRuntime) {
     case null:
     case undefined:

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -46,9 +46,11 @@ Specify a custom JSX runtime source to use. Allows to customize the import added
 
 Example: `jsxRuntimeImport: { source: 'preact', specifiers: ['h'] }` for "classic-preact" equivalent.
 
-| Default | CLI Override | API Override                                                 |
-| ------- | ------------ | ------------------------------------------------------------ |
-| `null`  | -            | `jsxRuntimeImport: { source: string, specifiers: string[] }` |
+To use the default import instead of a list of names, you can use `defaultSpecifier`, for example to use svgr with `hyperapp-jsx-pragma`, you can specify `jsxRuntimeImport: { source: 'hyperapp-jsx-pragma', defaultSpecifier: 'h' }` to get an end result of `import h from "hyperapp-jsx-pragma";`
+
+| Default | CLI Override | API Override                                                                           |
+| ------- | ------------ | -------------------------------------------------------------------------------------- |
+| `null`  | -            | `jsxRuntimeImport: { source: string, specifiers: string[], defaultSpecifier: string }` |
 
 ## Icon
 


### PR DESCRIPTION
## Summary

Right now I can't find a way to integrate svgr with my workflow (parcel2 building a hyperapp-based website), as there are a couple of missing things:

- no way to specify a custom JSX import config via a config file
- no way to use the custom JSX import config to specify that we want to use the default import

## Test plan

```
$ cat ~/Projects/KaraKara/browser2/package.json | jq .svgr
{
  "jsxRuntimeImport": {
    "source": "hyperapp-jsx-pragma",
    "defaultSpecifier": "h"
  },
  "icon": true,
  "replace-attr-values": "#4d4d4d=currentColor"
}

$ npx svgr ~/Projects/KaraKara/browser2/src/static/favicon.svg | head -n 5
import h from "hyperapp-jsx-pragma";
const SvgFavicon = (props) => (
...
```