### PR TITLE
Update package.json

### DIFF
--- a/packages/plugin-svgo/package.json
+++ b/packages/plugin-svgo/package.json
@@ -39,6 +39,6 @@
   "dependencies": {
     "cosmiconfig": "^7.0.1",
     "deepmerge": "^4.2.2",
-    "svgo": "^2.8.0"
+    "svgo": "^3.0.2"
   }
 }


### PR DESCRIPTION
Fix yarn warning @svgr/webpack > @svgr/plugin-svgo > svgo > stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
