### PR TITLE
docs: fix typo in remix docs

### DIFF
--- a/website/pages/docs/remix.mdx
+++ b/website/pages/docs/remix.mdx
@@ -14,7 +14,7 @@ Configure your [Remix](https://remix.run/) project to import SVG as React compon
 ## Install
 
 ```bash
-npm install --save-dev @svgr/cli @svgr/plugin-svgo @svgr/plugin-jsx @svgr/plugin-prettier npm-watch npm-run-allnpm-watch npm-run-all
+npm install --save-dev @svgr/cli @svgr/plugin-svgo @svgr/plugin-jsx @svgr/plugin-prettier npm-watch npm-run-all
 ```
 
 ## Usage


### PR DESCRIPTION
The doc [page of remix](https://react-svgr.com/docs/remix/#install) has incorrect package installation list.