### PR TITLE
feat: remove @svgr/plugin-jsx from core

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,7 +34,7 @@ Use `svgr.sync(code, config, state)` if you would like to use sync version.
 
 ### Plugins
 
-By default `@svgr/core` doesn't include `svgo` and `prettier` plugins, if you want them, you have to install them and include them in config.
+By default `@svgr/core` doesn't include any plugin, if you want them, you have to install them and include them in config.
 
 ```js
 svgr(svgCode, {
@@ -54,7 +54,3 @@ MIT
 [package]: https://www.npmjs.com/package/@svgr/core
 [license-badge]: https://img.shields.io/npm/l/@svgr/core.svg?style=flat-square
 [license]: https://github.com/smooth-code/svgr/blob/master/LICENSE
-
-```
-
-```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@babel/core": "^7.21.3",
     "@svgr/babel-preset": "^6.5.1",
-    "@svgr/plugin-jsx": "^6.5.1",
     "camelcase": "^6.2.0",
     "cosmiconfig": "^8.1.3"
   }

--- a/packages/core/src/plugins.test.ts
+++ b/packages/core/src/plugins.test.ts
@@ -16,12 +16,12 @@ describe('#getPlugins', () => {
     expect(getPlugins({}, state)).toEqual(['from-state-plugin'])
   })
 
-  it('should default to ["@svgr/plugin-jsx"]', () => {
-    expect(getPlugins({}, {})).toEqual([jsx])
+  it('should default to []', () => {
+    expect(getPlugins({}, {})).toEqual([])
   })
 
   it('should support caller with "defaultPlugins" in second choice', () => {
-    expect(getPlugins({}, { caller: {} })).toEqual([jsx])
+    expect(getPlugins({}, { caller: {} })).toEqual([])
   })
 })
 

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import jsx from '@svgr/plugin-jsx'
 import { Config } from './config'
 import type { State } from './state'
 
@@ -9,7 +7,7 @@ export interface Plugin {
 
 export type ConfigPlugin = string | Plugin
 
-const DEFAULT_PLUGINS: Plugin[] = [jsx as any]
+const DEFAULT_PLUGINS: Plugin[] = []
 
 export const getPlugins = (
   config: Config,


### PR DESCRIPTION
BREAKING CHANGE: plugin-jsx is no longer included by default in core
