### PR TITLE
docs: trim key and value when parse string setting to object

### DIFF
--- a/website/src/components/playground/config/settings.js
+++ b/website/src/components/playground/config/settings.js
@@ -3,7 +3,7 @@ const parseObject = (value) =>
     const [left, right] = assignment.split('=')
     return {
       ...obj,
-      [left]: right,
+      [left.trim()]: right.trim(),
     }
   }, {})
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
fix #817

 Trim key and value when parse string setting to object

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested locally, The SVG Props setting works fine even when a  new line occurs:
![image](https://user-images.githubusercontent.com/41503212/228786012-8283f97c-d83d-4d1d-a2fa-72101cef4f07.png)

