### PR TITLE
fix: parseObject error causes website broken

### DIFF
--- a/website/src/components/playground/config/settings.js
+++ b/website/src/components/playground/config/settings.js
@@ -3,7 +3,7 @@ const parseObject = (value) =>
     const [left, right] = assignment.split('=')
     return {
       ...obj,
-      [left.trim()]: right.trim(),
+      [left.trim()]: right?.trim(),
     }
   }, {})
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
fix #847 
I'm sorry, this [PR ](https://github.com/gregberge/svgr/pull/843)crashed the website playground.

```
const parseObject = (value) =>
  value.split(',').reduce((obj, assignment) => {
    const [left, right] = assignment.split('=')
    return {
      ...obj,
      [left.trim()]: right.trim(),
    }
  }, {})
```

`right` in the above function may be `undefined`, so `parseObject` will throw an error.
> Curious why the error is not visible in the console

## Test plan
The playground works even if  `REPLACE  ATTRIBUTES VALUE ` or  `SVG PROPS` are not set:

![image](https://user-images.githubusercontent.com/41503212/229542925-ec3f6b0b-01da-4646-a6e1-a4e77c5828d9.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
