### PR TITLE
Change `SVGProps` from import to import type

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
@@ -332,7 +332,7 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "descProp" and "expandProps" adds "desc", "descId" props and expands props 1`] = `
 "import * as React from "react";
-import { SVGProps } from "react";
+import type { SVGProps } from "react";
 interface SVGRProps {
   desc?: string;
   descId?: string;
@@ -347,7 +347,7 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "expandProps" add props 1`] = `
 "import * as React from "react";
-import { SVGProps } from "react";
+import type { SVGProps } from "react";
 const SvgComponent = (props: SVGProps<SVGSVGElement>) => <svg><g /></svg>;
 export default SvgComponent;"
 `;
@@ -377,7 +377,8 @@ export default img;"
 
 exports[`plugin typescript with "native" and "expandProps" option adds import from "react-native-svg" and adds props 1`] = `
 "import * as React from "react";
-import Svg, { SvgProps } from "react-native-svg";
+import Svg from "react-native-svg";
+import type { SvgProps } from "react-native-svg";
 const SvgComponent = (props: SvgProps) => <Svg><g /></Svg>;
 export default SvgComponent;"
 `;
@@ -391,7 +392,8 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "native", "ref" and "expandProps" option adds import from "react-native-svg" and adds props and adds ForwardRef component 1`] = `
 "import * as React from "react";
-import Svg, { SvgProps } from "react-native-svg";
+import Svg from "react-native-svg";
+import type { SvgProps } from "react-native-svg";
 import { Ref, forwardRef } from "react";
 const SvgComponent = (props: SvgProps, ref: Ref<SVGSVGElement>) => <Svg><g /></Svg>;
 const ForwardRef = forwardRef(SvgComponent);
@@ -409,7 +411,8 @@ export default ForwardRef;"
 
 exports[`plugin typescript with "ref" and "expandProps" option expands props 1`] = `
 "import * as React from "react";
-import { SVGProps, Ref, forwardRef } from "react";
+import type { SVGProps } from "react";
+import { Ref, forwardRef } from "react";
 const SvgComponent = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => <svg><g /></svg>;
 const ForwardRef = forwardRef(SvgComponent);
 export default ForwardRef;"
@@ -425,7 +428,7 @@ export default ForwardRef;"
 
 exports[`plugin typescript with "titleProp" "descProp" and "expandProps" adds "title", "titleId", "desc", "descId" props and expands props 1`] = `
 "import * as React from "react";
-import { SVGProps } from "react";
+import type { SVGProps } from "react";
 interface SVGRProps {
   title?: string;
   titleId?: string;
@@ -474,7 +477,7 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "titleProp" and "expandProps" adds "title", "titleId" props and expands props 1`] = `
 "import * as React from "react";
-import { SVGProps } from "react";
+import type { SVGProps } from "react";
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/packages/babel-plugin-transform-svg-component/src/variables.ts
+++ b/packages/babel-plugin-transform-svg-component/src/variables.ts
@@ -34,7 +34,7 @@ const getOrCreateImport = (
   )
   if (existing) return existing
   const imp = t.importDeclaration([], t.stringLiteral(sourceValue))
-  if (importKind) {
+  if (importKind !== undefined) {
     imp.importKind = importKind
   }
   imports.push(imp)

--- a/packages/cli/src/__snapshots__/index.test.ts.snap
+++ b/packages/cli/src/__snapshots__/index.test.ts.snap
@@ -468,7 +468,8 @@ export default SvgFile
 
 exports[`cli should support various args: --typescript --ref --desc-prop 1`] = `
 "import * as React from 'react'
-import { SVGProps, Ref, forwardRef } from 'react'
+import type { SVGProps } from 'react'
+import { Ref, forwardRef } from 'react'
 interface SVGRProps {
   desc?: string;
   descId?: string;
@@ -497,7 +498,8 @@ export default ForwardRef
 
 exports[`cli should support various args: --typescript --ref --title-prop 1`] = `
 "import * as React from 'react'
-import { SVGProps, Ref, forwardRef } from 'react'
+import type { SVGProps } from 'react'
+import { Ref, forwardRef } from 'react'
 interface SVGRProps {
   title?: string;
   titleId?: string;
@@ -526,7 +528,8 @@ export default ForwardRef
 
 exports[`cli should support various args: --typescript --ref 1`] = `
 "import * as React from 'react'
-import { SVGProps, Ref, forwardRef } from 'react'
+import type { SVGProps } from 'react'
+import { Ref, forwardRef } from 'react'
 const SvgFile = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -546,7 +549,7 @@ export default ForwardRef
 
 exports[`cli should support various args: --typescript 1`] = `
 "import * as React from 'react'
-import { SVGProps } from 'react'
+import type { SVGProps } from 'react'
 const SvgFile = (props: SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={48} height={1} {...props}>
     <path fill="#063855" fillRule="evenodd" d="M0 0h48v1H0z" />


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR changes `SVGProp` from value import to type import when the `--typescript` flag is supplied.

Here's an example of the change:

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/331432/230798120-40b05903-3eec-40f9-935b-da99a1e4e143.png">

The change is quite straightforward. It adds a `importKind` parameter to the `getOrCreateImport` method so that both when importing the react and react-native versions of `SVGProps`, we can create the `ImportDeclaration` node with the right `importKind` parameter.

This addresses the warning for `verbatimModuleSyntax` [flag](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax) in Typescript 5.0, seen below[they shipped the --verbatimModuleSyntax flag]

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/331432/228081669-fa357988-32ed-49ab-b05e-fd841bec9c22.png">

Note: this PR is branched off f20a753 because the build was failing in the newer commits.

This PR addresses #842 

## Test plan

I ran the jest tests and inspected the generated output to make sure they are correct.

I ran the updated script against my folder of SVGs and the Typescript compiler was happy with them.