### PR TITLE
feature: 858 Index template improvements

### DIFF
--- a/__fixtures__/custom-index-template.js
+++ b/__fixtures__/custom-index-template.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 function indexTemplate(files) {
-  const exportEntries = files.map(file => {
+  const exportEntries = files.map(({path: file}) => {
     const basename = path.basename(file, path.extname(file))
     return `export { ${basename} } from './${basename}';`
   })

--- a/website/pages/docs/cli.mdx
+++ b/website/pages/docs/cli.mdx
@@ -99,7 +99,7 @@ Advanced use cases could lead you to customize the index template. The `--index-
 const path = require('path')
 
 function defaultIndexTemplate(filePaths) {
-  const exportEntries = filePaths.map((filePath) => {
+  const exportEntries = filePaths.map(({ path: filePath }) => {
     const basename = path.basename(filePath, path.extname(filePath))
     const exportName = /^\d/.test(basename) ? `Svg${basename}` : basename
     return `export { default as ${exportName} } from './${basename}'`

--- a/website/pages/docs/custom-templates.mdx
+++ b/website/pages/docs/custom-templates.mdx
@@ -40,7 +40,7 @@ ${variables.interfaces};
 const ${variables.componentName} = (${variables.props}) => (
   ${variables.jsx}
 );
- 
+
 ${variables.exports};
 `
 }
@@ -105,7 +105,7 @@ The customization is the same, a file that exports a function:
 const path = require('path')
 
 function defaultIndexTemplate(filePaths) {
-  const exportEntries = filePaths.map((filePath) => {
+  const exportEntries = filePaths.map(({ path: filePath }) => {
     const basename = path.basename(filePath, path.extname(filePath))
     const exportName = /^\d/.test(basename) ? `Svg${basename}` : basename
     return `export { default as ${exportName} } from './${basename}'`


### PR DESCRIPTION
index-template now receives an array of objects containing both the created component path (`path`) and the original svg path (`originalPath`).
It is a response to issue #858.

## Summary

As before-mentioned, it responds to issue #858, that is, allow index templates to know the original file handled's path.

## Test plan

You can use this template. It should create an index.js file containing an object `map` containing the mapping between the original svg file name and the react component.

```js
const path = require('path');

function defaultIndexTemplate(filePaths) {
  const entries = filePaths.map(({path: filePath, originalPath}) => {
    const originalFileName = path.basename(
      originalPath,
      path.extname(originalPath),
    );
    const basename = path.basename(filePath, path.extname(filePath));
    const exportName = /^\d/.test(basename) ? `Svg${basename}` : basename;
    const importLine = `import ${exportName} from './${basename}';`;
    const mapLine = `${
      /.*[.-].*/.test(originalFileName)
        ? `'${originalFileName}'`
        : originalFileName
    }: ${exportName}`;
    return [importLine, mapLine];
  });
  return `${entries.map(([e]) => e).join('\n')}
export const map = {
${entries.map(([, e]) => e).join(',\n')}
}
`;
}

module.exports = defaultIndexTemplate;
```
