### PR TITLE
Fix JSX Options Being Ignored In Babel Transpiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules/
 lib/
 dist/

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -1,11 +1,13 @@
 import { Config } from './config'
 import type { State } from './state'
 
+type Default<T> = { default: T }
+
 export interface Plugin {
   (code: string, config: Config, state: State): string
 }
 
-export type ConfigPlugin = string | Plugin
+export type ConfigPlugin = string | Plugin | Default<string | Plugin>
 
 const DEFAULT_PLUGINS: Plugin[] = []
 
@@ -24,7 +26,12 @@ export const getPlugins = (
   return DEFAULT_PLUGINS
 }
 
-export const resolvePlugin = (plugin: ConfigPlugin): Plugin => {
+export const resolvePlugin = (input: ConfigPlugin): Plugin => {
+  const plugin: string | Plugin =
+    (input as Default<string | Plugin>)?.default != null
+      ? (input as Default<string | Plugin>).default
+      : (input as string | Plugin)
+
   if (typeof plugin === 'function') {
     return plugin
   }

--- a/packages/plugin-jsx/src/index.ts
+++ b/packages/plugin-jsx/src/index.ts
@@ -6,7 +6,7 @@ import svgrBabelPreset, {
 } from '@svgr/babel-preset'
 import type { Plugin, Config } from '@svgr/core'
 
-const getJsxRuntimeOptions = (config: Config): Partial<SvgrPresetOptions> => {
+export const getJsxRuntimeOptions = (config: Config): Partial<SvgrPresetOptions> => {
   if (config.jsxRuntimeImport) {
     return {
       importSource: config.jsxRuntimeImport.source,

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -14,11 +14,29 @@ import presetTS from '@babel/preset-typescript'
 import pluginTransformReactConstantElements from '@babel/plugin-transform-react-constant-elements'
 import type { PluginImpl } from 'rollup'
 
+// Removes `jsx` prefix from options (e.g. jsxRuntime -> runtime)
+const transformJsxOptions = (config: Config): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(config).map(([key, value]) => {
+      if (!key.startsWith('jsx')) return [key, value]
+
+      return [
+        key
+          .replace(/^jsx/, '')
+          .replace(/^([A-Z])/, (match) => `${match.toLowerCase()}`),
+        value,
+      ]
+    }),
+  )
+
 const getBabelOptions = (config: Config) => ({
   babelrc: false,
   configFile: false,
   presets: [
-    ['@babel/preset-react', getJsxRuntimeOptions(config)],
+    createConfigItem(
+      [presetReact, transformJsxOptions(getJsxRuntimeOptions(config))],
+      { type: 'preset' },
+    ),
     createConfigItem([presetEnv, { modules: false }], { type: 'preset' }),
   ],
   plugins: [createConfigItem(pluginTransformReactConstantElements)],

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -14,13 +14,29 @@ import presetTS from '@babel/preset-typescript'
 import pluginTransformReactConstantElements from '@babel/plugin-transform-react-constant-elements'
 import type * as webpack from 'webpack'
 
+// Removes `jsx` prefix from options (e.g. jsxRuntime -> runtime)
+const transformJsxOptions = (config: Config): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(config).map(([key, value]) => {
+      if (!key.startsWith('jsx')) return [key, value]
+
+      return [
+        key
+          .replace(/^jsx/, '')
+          .replace(/^([A-Z])/, (match) => `${match.toLowerCase()}`),
+        value,
+      ]
+    }),
+  )
+
 const getBabelOptions = (config: Config) => ({
   babelrc: false,
   configFile: false,
   presets: [
-    createConfigItem([presetReact, getJsxRuntimeOptions(config)], {
-      type: 'preset',
-    }),
+    createConfigItem(
+      [presetReact, transformJsxOptions(getJsxRuntimeOptions(config))],
+      { type: 'preset' },
+    ),
     createConfigItem([presetEnv, { modules: false }], { type: 'preset' }),
   ],
   plugins: [createConfigItem(pluginTransformReactConstantElements)],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

An improvement of #748, this PR fixes the issue that the JSX transform options are not used when using babel to transpile the output. The old PR added a duplicate option for it, this one reuses the existing JSX options.

**It's really ugly and duplicates a bunch of code**, but I wasn't sure where to put the shared code so I'll let you edit it to whatever you want.

I also updated the `resolvePlugin` function to handle modules that don't just export a single default export.

## Test plan

I ran this command after linking the built packages to my repo:

```
pnpm build; open dist/.../large.svg.js | str contains "React.createElement"
```

and got the response `false`.

fixes #801 
