### PR TITLE
Memo External URL Change

### DIFF
--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -147,7 +147,7 @@ Setting this to `true` will forward ref to the root SVG tag.
 
 ## Memo
 
-Setting this to `true` will wrap the exported component in [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo).
+Setting this to `true` will wrap the exported component in [`React.memo`](https://react.dev/reference/react/memo).
 
 | Default | CLI Override | API Override    |
 | ------- | ------------ | --------------- |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Since React's official documentation has changed, I thought it was appropriate to change the `Memo` reference link in the `Options` section.

## Test plan

I just changed the url with the new url.
