### PR TITLE
Update docs (nextjs, next.config.js)

### DIFF
--- a/website/pages/docs/next.mdx
+++ b/website/pages/docs/next.mdx
@@ -29,9 +29,9 @@ Using SVGR in Next.js is possible with `@svgr/webpack`.
 module.exports = {
   webpack(config) {
     // Grab the existing rule that handles SVG imports
-    const fileLoaderRule = config.module.rules.find((rule) =>
-      rule.test?.test?.('.svg'),
-    )
+    const fileLoaderRule = config.module.rules.find(
+      (rule) => rule.test && rule.test instanceof RegExp && rule.test.test(".svg")
+    );
 
     config.module.rules.push(
       // Reapply the existing rule, but only for svg imports ending in ?url


### PR DESCRIPTION
## Summary

I've made a small contribution aimed at addressing an issue noted in [#860](https://github.com/gregberge/svgr/issues/860). The problem was concerning the possibility of a TypeError occurring in the next.config.js example code provided in the svgr documentation.

It is possible for a TypeError to occur if rule.test is not an instance of RegExp but some other type that does not have the .test method. In response to this issue, I've added a type check to see if rule.test is an instance of RegExp to enhance the robustness of the code.

## Test plan

To demonstrate the solidity of the code changes, the following steps will be executed:

Install Next.js version 13 or higher.
Follow the instructions provided in the documentation to set up and configure the next.config.js file.
Set up SVGR according to the documentation.
Run the application.