### PR TITLE
fix: :bug: fixed duplicate react-native-svg duplicate import

### DIFF
--- a/packages/babel-plugin-transform-react-native-svg/src/index.ts
+++ b/packages/babel-plugin-transform-react-native-svg/src/index.ts
@@ -79,7 +79,10 @@ const plugin = () => {
 
   const importDeclarationVisitor = {
     ImportDeclaration(path: NodePath<t.ImportDeclaration>, state: State) {
-      if (path.get('source').isStringLiteral({ value: 'react-native-svg' })) {
+      if (
+        path.get('source').isStringLiteral({ value: 'react-native-svg' }) &&
+        !path.get('importKind').hasNode()
+      ) {
         state.replacedComponents.forEach((component) => {
           if (
             path


### PR DESCRIPTION
This PR resolved #891 

## Summary

When updating the imports of react-native-svg there is no check on the importKind. This would cause a wrong update import and a crash in the cli. This bug occurs when combining expandProp, native and typescript in the config.

## Current Output

```js
import * as React from "react";
import Svg, { Path } from "react-native-svg";
//     ^^^   ^^^^^
import type { SvgProps, Svg, Path } from "react-native-svg";
//                      ^^^^^^^^^
```

## Fixed Output
```js
import * as React from "react";
import Svg, { Path } from "react-native-svg";
import type { SvgProps } from "react-native-svg";
```

## Test plan

Run the cli with expandProp, native and typescript in the config. It used to crash and complain about duplicate imports.

## Acknowledgement

Thanks to @atomicpages for their investigative work, it helped me track the bug.
