### PR TITLE
Export run() function

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { transform } from './transform'
+export { transform, run } from './transform'
 export * from './config'
 export type { State } from './state'
 export type { Plugin, ConfigPlugin } from './plugins'

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -4,7 +4,7 @@ import { resolvePlugin, getPlugins } from './plugins'
 import type { Config } from './config'
 import type { State } from './state'
 
-const run = (code: string, config: Config, state: Partial<State>): string => {
+export const run = (code: string, config: Config, state: Partial<State>): string => {
   const expandedState = expandState(state)
   const plugins = getPlugins(config, state).map(resolvePlugin)
   let nextCode = String(code).replace('\0', '')


### PR DESCRIPTION
`transform()` function depends on node.js API and cannot be used in browser environment. But `run()` probably can.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
