### PR TITLE
chore: upgrade cosmiconfig

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.21.3",
     "@svgr/babel-preset": "workspace:*",
     "camelcase": "^6.2.0",
-    "cosmiconfig": "^8.1.3",
+    "cosmiconfig": "^8.3.6",
     "snake-case": "^3.0.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,8 +248,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       cosmiconfig:
-        specifier: ^8.1.3
-        version: 8.1.3
+        specifier: ^8.3.6
+        version: 8.3.6(typescript@5.0.2)
       snake-case:
         specifier: ^3.0.4
         version: 3.0.4
@@ -4673,6 +4673,22 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    dev: false
+
+  /cosmiconfig@8.3.6(typescript@5.0.2):
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      typescript: 5.0.2
     dev: false
 
   /cross-spawn@7.0.3:
@@ -10700,7 +10716,6 @@ packages:
     resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
     engines: {node: '>=12.20'}
     hasBin: true
-    dev: true
 
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Upgrade to cosmiconfig 8.3.6, which fixes an unhandled exception when traversing parent directories looking for directories named `.config`. If a parent directory contained a file named `.config`, before this fix, generated React apps would fail to start. I documented this bug in https://github.com/facebook/create-react-app/issues/13355#issuecomment-1705159226 but I believe the issue originates from within this library.

## Test plan

I followed the steps documented in CONTRIBUTING.md.

- [x] `pnpm install`
- [x] `pnpm run dev` still works
- [x] `pnpm run lint` passes (All matched files use Prettier code style!)
- [x] `pnpm run test` succeeds (245 passed, 245 total)
