### PR TITLE
Fix check for type imports in transform-react-native-svg

### DIFF
--- a/packages/babel-plugin-transform-react-native-svg/src/index.test.ts
+++ b/packages/babel-plugin-transform-react-native-svg/src/index.test.ts
@@ -26,4 +26,29 @@ describe('plugin', () => {
       <Svg><G /></Svg>;"
     `)
   })
+
+  it('should add deal with type imports properly', () => {
+    const code = transform(
+      `
+      import Svg from 'react-native-svg';
+      import type { SvgProps } from "react-native-svg";
+
+      const ComponentSvg = () => <svg><g /></svg>;
+    `,
+      {
+        plugins: [
+          '@babel/plugin-syntax-jsx',
+          ['@babel/plugin-syntax-typescript', { isTSX: true }],
+          plugin,
+        ],
+        configFile: false,
+      },
+    )?.code
+
+    expect(code).toMatchInlineSnapshot(`
+      "import Svg, { G } from 'react-native-svg';
+      import type { SvgProps } from "react-native-svg";
+      const ComponentSvg = () => <Svg><G /></Svg>;"
+    `)
+  })
 })

--- a/packages/babel-plugin-transform-react-native-svg/src/index.ts
+++ b/packages/babel-plugin-transform-react-native-svg/src/index.ts
@@ -79,9 +79,13 @@ const plugin = () => {
 
   const importDeclarationVisitor = {
     ImportDeclaration(path: NodePath<t.ImportDeclaration>, state: State) {
+      const isNotTypeImport =
+        !path.get('importKind').hasNode() ||
+        path.node.importKind == null ||
+        path.node.importKind === 'value'
       if (
         path.get('source').isStringLiteral({ value: 'react-native-svg' }) &&
-        !path.get('importKind').hasNode()
+        isNotTypeImport
       ) {
         state.replacedComponents.forEach((component) => {
           if (


### PR DESCRIPTION
## Summary

I was trying to use the babel-plugin-transform-react-native-svg separately in babel without svgr and hit an issue where it wouldn't update the import declaration.

I managed to pin it down to the new check added in #894. As per [the babel spec](https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#importdeclaration) for imports, `importKind` will be `null | 'type' | 'typeof' | 'value'`. When using babel to parse an existing import, its being parsed as `'value'`...

I think its `null` when working with svgr because [when we add the import declaration to the AST](https://github.com/gregberge/svgr/blob/main/packages/babel-plugin-transform-svg-component/src/variables.ts#L133-L135), we don't specify the import kind parameter when calling `getOrCreateImport`.

## Test plan

Add a new test to `index.test.ts` for `babel-plugin-transform-react-native-svg`:

```
$ pnpm run test babel-plugin-transform-react-native-svg
```

Before my changes:
<img width="1184" alt="image" src="https://github.com/gregberge/svgr/assets/10435324/62b7ce08-59a4-4a66-a1f0-e84d9b3372ca">

After my changes:
<img width="840" alt="image" src="https://github.com/gregberge/svgr/assets/10435324/b94a121f-7c91-4170-b31a-22ae953748ce">
