### PR TITLE
feat: export `LoaderOptions` from `@svgr/webpack`

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -35,7 +35,7 @@ const typeScriptBabelOptions = {
   ],
 }
 
-interface LoaderOptions extends Config {
+export interface LoaderOptions extends Config {
   babel?: boolean
 }
 


### PR DESCRIPTION
## Summary

When passing options to `@svgr/webpack`, I'd like to write them with typing like this:
```ts
rules: [{
  test: /\.svg$/i,
  issuer: /\.[jt]sx?$/,
  use: [{
    loader: '@svgr/webpack',
    /** @type {import('@svgr/webpack').LoaderOptions} */
    options: { icon: true } }],
}],
```
I can import the `Config` type from `@svgr/core`, but package managers like pnpm need to install `@svgr/core` for that.
