### PR TITLE
Fix react-native ref type

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
@@ -395,7 +395,7 @@ exports[`plugin typescript with "native", "ref" and "expandProps" option adds im
 import Svg from "react-native-svg";
 import type { SvgProps } from "react-native-svg";
 import { Ref, forwardRef } from "react";
-const SvgComponent = (props: SvgProps, ref: Ref<SVGSVGElement>) => <Svg><g /></Svg>;
+const SvgComponent = (props: SvgProps, ref: Ref<Svg>) => <Svg><g /></Svg>;
 const ForwardRef = forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
@@ -404,7 +404,7 @@ exports[`plugin typescript with "native", "ref" option adds import from "react-n
 "import * as React from "react";
 import Svg from "react-native-svg";
 import { Ref, forwardRef } from "react";
-const SvgComponent = (_, ref: Ref<SVGSVGElement>) => <Svg><g /></Svg>;
+const SvgComponent = (_, ref: Ref<Svg>) => <Svg><g /></Svg>;
 const ForwardRef = forwardRef(SvgComponent);
 export default ForwardRef;"
 `;

--- a/packages/babel-plugin-transform-svg-component/src/variables.ts
+++ b/packages/babel-plugin-transform-svg-component/src/variables.ts
@@ -66,6 +66,12 @@ const tsTypeReferenceSVGRef = (ctx: Context) => {
   getOrCreateImport(ctx, ctx.importSource).specifiers.push(
     t.importSpecifier(identifier, identifier),
   )
+  if (ctx.opts.native) {
+    return t.tsTypeReference(
+      identifier,
+      t.tsTypeParameterInstantiation([t.tsTypeReference(t.identifier('Svg'))]),
+    )
+  }
   return t.tsTypeReference(
     identifier,
     t.tsTypeParameterInstantiation([


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fix the invalid forward ref type when using `native`, `typescript` and `ref` options

```tsx
import Svg, { Path } from 'react-native-svg'
import type { SvgProps } from 'react-native-svg'
import { Ref, forwardRef } from 'react'
const Icon = (props: SvgProps, ref: Ref<SVGSVGElement>) => (
  <Svg
    xmlns="http://www.w3.org/2000/svg"
    fill="none"
    viewBox="0 0 24 24"
	// ↓ TS complains about a mismatch between SVGSVGElement and Svg from `react-native-svg`
    ref={ref}
    {...props}
  >
    {/* ... */}
  </Svg>
)
const ForwardRef = forwardRef(SvgUserHeart)
export default ForwardRef

```

When using native the type must be `Svg`

```diff
import Svg, { Path } from 'react-native-svg'
import type { SvgProps } from 'react-native-svg'
import { Ref, forwardRef } from 'react'
-const Icon = (props: SvgProps, ref: Ref<SVGSVGElement>) => (
+const Icon = (props: SvgProps, ref: Ref<Svg>) => (
  <Svg
    xmlns="http://www.w3.org/2000/svg"
    fill="none"
    viewBox="0 0 24 24"
    ref={ref}
    {...props}
  >
    {/* ... */}
  </Svg>
)
const ForwardRef = forwardRef(SvgUserHeart)
export default ForwardRef
```

## Test plan

Check updated snapshots
