### PR TITLE
correct twitter handle link

### DIFF
--- a/website/src/components/playground/Playground.js
+++ b/website/src/components/playground/Playground.js
@@ -222,7 +222,7 @@ function CopyFeedback(props) {
           <x.div my={24}>
             <SponsorLink
               onClick={trackLink}
-              href="https://twitter.com/neoziro"
+              href="https://twitter.com/gregberge_"
               target="_blank"
               rel="noopener noreferrer"
               bg="#1DA1F3"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

While using the website, I noticed that when you click the "Follow me on Twitter" button, it takes you to a random account with 22 followers instead of @gregberge_, the creator of this repo's twitter account as shown on his website, also linked in this repo.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
The change is very small and uses only existing code, only swapping the handle in the link for the correct one. I tested it by copying the link and putting it into my browser to confirm it is correct