### PR TITLE
Add support for preserving original filename casing with `--filename-case=keep`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ Options:
   -d, --out-dir <dirname>          output files into a directory
   --ignore-existing                ignore existing files when used with --out-dir
   --ext <ext>                      specify a custom file extension (default: "js")
-  --filename-case <case>           specify filename case ("pascal", "kebab", "camel", "snake") (default: "pascal")
+  --filename-case <case>           specify filename case ("pascal", "kebab", "camel", "snake", "keep") (default: "pascal")
   --icon                           use "1em" as width and height
   --native                         add react-native support with react-native-svg
   --memo                           add React.memo into the result component

--- a/packages/cli/src/__snapshots__/index.test.ts.snap
+++ b/packages/cli/src/__snapshots__/index.test.ts.snap
@@ -129,6 +129,16 @@ exports[`cli should support different filename cases with directory output: --fi
 ]
 `;
 
+exports[`cli should support different filename cases with directory output: --filename-case=keep 1`] = `
+[
+  "PascalCase.js",
+  "camelCase.js",
+  "index.js",
+  "kebab-case.js",
+  "multiple---dashes.js",
+]
+`;
+
 exports[`cli should support different filename cases with directory output: --filename-case=pascal 1`] = `
 [
   "CamelCase.js",

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -155,6 +155,7 @@ describe('cli', () => {
     [2, '--filename-case=pascal'],
     [3, '--filename-case=kebab'],
     [4, '--filename-case=snake'],
+    [5, '--filename-case=keep'],
   ])(
     'should support different filename cases with directory output',
     async (index, args) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -103,7 +103,7 @@ program
   .option('--ext <ext>', 'specify a custom file extension (default: "js")')
   .option(
     '--filename-case <case>',
-    'specify filename case ("pascal", "kebab", "camel", "snake") (default: "pascal")',
+    'specify filename case ("pascal", "kebab", "camel", "snake", "keep") (default: "pascal")',
   )
   .option(
     '--icon [size]',

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -24,6 +24,8 @@ export function transformFilename(
       return camelCase(filename, { pascalCase: true })
     case 'snake':
       return snakeCase(filename)
+    case 'keep':
+      return filename
     default:
       throw new Error(`Unknown --filename-case ${filenameCase}`)
   }

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -253,7 +253,8 @@ When used with `--out-dir`, it ignores already existing files.
 
 ## Filename case
 
-Specify a custom filename case. Possible values: `pascal` for PascalCase, `kebab` for kebab-case, `camel` for camelCase, or `snake` for snake_case.
+Specify a custom filename case. Possible values: `pascal` for PascalCase, `kebab` for kebab-case, `camel` for camelCase, `snake` for snake_case, or `keep`
+to preserve original filename casing.
 
 | Default  | CLI Override      | API Override           |
 | -------- | ----------------- | ---------------------- |


### PR DESCRIPTION
## Summary

As discussed a long time ago in https://github.com/gregberge/svgr/issues/716, this adds support for preserving original filename casing by adding a `keep` option to `--filename-case`.

## Test plan

- Added new test snapshot for new feature
