### PR TITLE
glob upgraded to v11, v8 is deprecated

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "chalk": "^4.1.2",
     "commander": "^9.4.1",
     "dashify": "^2.0.0",
-    "glob": "^8.0.3",
+    "glob": "^11.0.1",
     "snake-case": "^3.0.4"
   },
   "devDependencies": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { program, Command } from 'commander'
 import * as path from 'path'
-import { glob } from 'glob'
+import { globSync } from 'glob'
 import { readFileSync, promises as fsPromises } from 'fs'
 import { loadConfig, Config } from '@svgr/core'
 import { fileCommand } from './fileCommand'
@@ -178,7 +178,7 @@ program.parse(process.argv)
 async function run() {
   const errors: string[] = []
   const filenames = program.args.reduce((globbed, input) => {
-    let files = glob.sync(input)
+    let files = globSync(input)
     if (!files.length) files = [input]
     return [...globbed, ...files]
   }, [] as string[])


### PR DESCRIPTION
glob v8 is currently depricated, this PR upgrade glob to latest v11.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
