### PR TITLE
Replace snake-case and camelcase with change-case

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,12 +35,11 @@
     "@svgr/plugin-jsx": "workspace:*",
     "@svgr/plugin-prettier": "workspace:*",
     "@svgr/plugin-svgo": "workspace:*",
-    "camelcase": "^6.2.0",
     "chalk": "^4.1.2",
+    "change-case": "^4.0.0",
     "commander": "^9.4.1",
     "dashify": "^2.0.0",
-    "glob": "^8.0.3",
-    "snake-case": "^3.0.4"
+    "glob": "^8.0.3"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/packages/cli/src/util.test.ts
+++ b/packages/cli/src/util.test.ts
@@ -39,7 +39,7 @@ describe('util', () => {
       expect(formatExportName('foo')).toBe('Foo')
       expect(formatExportName('foo-bar')).toBe('FooBar')
       expect(formatExportName('2foo')).toBe('Svg2foo')
-      expect(formatExportName('2foo-bar')).toBe('Svg2FooBar')
+      expect(formatExportName('2foo-bar')).toBe('Svg2fooBar')
     })
   })
 })

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -6,10 +6,8 @@ import svgo from '@svgr/plugin-svgo'
 import jsx from '@svgr/plugin-jsx'
 import prettier from '@svgr/plugin-prettier'
 // @ts-ignore
-import camelCase from 'camelcase'
-// @ts-ignore
 import dashify from 'dashify'
-import { snakeCase } from 'snake-case'
+import { camelCase, pascalCase, snakeCase } from 'change-case'
 
 export function transformFilename(
   filename: string,
@@ -21,7 +19,7 @@ export function transformFilename(
     case 'camel':
       return camelCase(filename)
     case 'pascal':
-      return camelCase(filename, { pascalCase: true })
+      return pascalCase(filename)
     case 'snake':
       return snakeCase(filename)
     default:
@@ -64,12 +62,12 @@ export const politeWrite = (data: string, silent?: boolean): void => {
 
 export const formatExportName = (name: string): string => {
   if (/[-]/g.test(name) && /^\d/.test(name)) {
-    return `Svg${camelCase(name, { pascalCase: true })}`
+    return `Svg${pascalCase(name)}`
   }
 
   if (/^\d/.test(name)) {
     return `Svg${name}`
   }
 
-  return camelCase(name, { pascalCase: true })
+  return pascalCase(name)
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,9 +40,8 @@
   "dependencies": {
     "@babel/core": "^7.21.3",
     "@svgr/babel-preset": "workspace:*",
-    "camelcase": "^6.2.0",
-    "cosmiconfig": "^8.3.6",
-    "snake-case": "^3.0.4"
+    "change-case": "^4.0.0",
+    "cosmiconfig": "^8.3.6"
   },
   "devDependencies": {
     "svgo": "^3.0.2"

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -1,6 +1,5 @@
 import { parse as parsePath } from 'path'
-// @ts-ignore
-import camelCase from 'camelcase'
+import { pascalCase } from 'change-case'
 import type { ConfigPlugin } from './plugins'
 
 export interface State {
@@ -17,11 +16,8 @@ const VALID_CHAR_REGEX = /[^a-zA-Z0-9 _-]/g
 
 const getComponentName = (filePath?: string): string => {
   if (!filePath) return 'SvgComponent'
-  const pascalCaseFileName = camelCase(
+  const pascalCaseFileName = pascalCase(
     parsePath(filePath).name.replace(VALID_CHAR_REGEX, ''),
-    {
-      pascalCase: true,
-    },
   )
   return `Svg${pascalCaseFileName}`
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -210,12 +206,12 @@ importers:
       '@svgr/plugin-svgo':
         specifier: workspace:*
         version: link:../plugin-svgo
-      camelcase:
-        specifier: ^6.2.0
-        version: 6.2.0
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
+      change-case:
+        specifier: ^4.0.0
+        version: 4.0.0
       commander:
         specifier: ^9.4.1
         version: 9.4.1
@@ -225,9 +221,6 @@ importers:
       glob:
         specifier: ^8.0.3
         version: 8.0.3
-      snake-case:
-        specifier: ^3.0.4
-        version: 3.0.4
     devDependencies:
       '@types/glob':
         specifier: ^8.1.0
@@ -244,15 +237,12 @@ importers:
       '@svgr/babel-preset':
         specifier: workspace:*
         version: link:../babel-preset
-      camelcase:
-        specifier: ^6.2.0
-        version: 6.2.0
+      change-case:
+        specifier: ^4.0.0
+        version: 4.0.0
       cosmiconfig:
         specifier: ^8.3.6
         version: 8.3.6(typescript@5.0.2)
-      snake-case:
-        specifier: ^3.0.4
-        version: 3.0.4
     devDependencies:
       svgo:
         specifier: ^3.0.2
@@ -4036,7 +4026,6 @@ packages:
     dependencies:
       pascal-case: 3.1.2
       tslib: 2.5.0
-    dev: true
 
   /camelcase-keys@2.1.0:
     resolution: {integrity: sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==}
@@ -4082,9 +4071,18 @@ packages:
   /camelcase@6.2.0:
     resolution: {integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==}
     engines: {node: '>=10'}
+    dev: true
 
   /caniuse-lite@1.0.30001474:
     resolution: {integrity: sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==}
+
+  /capital-case@1.0.4:
+    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.5.0
+      upper-case-first: 2.0.2
+    dev: false
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -4108,6 +4106,22 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  /change-case@4.0.0:
+    resolution: {integrity: sha512-SczylNA90FemLuJkMuQwcfudNjpB8VOz8IInWIai/R/6o7dRDvCsAnYSW99XhNi2zSkCLUYhnIiz52L87FQckQ==}
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+    dev: false
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -4395,6 +4409,14 @@ packages:
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
+
+  /constant-case@3.0.4:
+    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.5.0
+      upper-case: 2.0.2
+    dev: false
 
   /content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -6240,6 +6262,13 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
+
+  /header-case@2.0.4:
+    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.5.0
+    dev: false
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -9005,7 +9034,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.5.0
-    dev: true
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -9072,7 +9100,13 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.5.0
-    dev: true
+
+  /path-case@3.0.4:
+    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.5.0
+    dev: false
 
   /path-exists@2.1.0:
     resolution: {integrity: sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==}
@@ -9926,6 +9960,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /sentence-case@3.0.4:
+    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.5.0
+      upper-case-first: 2.0.2
+    dev: false
 
   /serialize-javascript@6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
@@ -10817,6 +10859,18 @@ packages:
       escalade: 3.1.1
       picocolors: 1.0.0
 
+  /upper-case-first@2.0.2:
+    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+
+  /upper-case@2.0.2:
+    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
@@ -11348,3 +11402,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Summary

I noticed this PR still hanging
https://github.com/gregberge/svgr/pull/938/, for this issue: https://github.com/gregberge/svgr/issues/937

This should resolve the suggestions by replacing both these old packages with a new leaner one.

Using version 4.x of change-case, as 5.x has done a rewrite to ESM-only.

There is one behavior change in how pascalCase works (I haven't been able to find any alternative library that retains the behavior of the camelcase library wrt pascal-case after a leading number).

In the future, for instance after dropping node 18.x support (soon EOL), we can also target using change-case 5.x.

## Test plan

I updated one assert here to reflect a behavior change in pascal-case. Let me know whether that is a dealbreaker and existing behavior needs to be retained in some way.