### PR TITLE
docs: add Turbopack configuration instructions to Next.js documentation

### DIFF
--- a/website/pages/docs/next.mdx
+++ b/website/pages/docs/next.mdx
@@ -123,3 +123,23 @@ Add the type decleration file to your tsconfig.json's `include` array. **Ensure 
   // ...other config
 }
 ```
+
+## Turbopack
+
+When using Turbopack, make sure to update your `next.config.js` file according to the official Next.js documentation to ensure compatibility and optimal performance.
+
+**next.config.js**
+```
+module.exports = {
+  turbopack: {
+    rules: {
+      '*.svg': {
+        loaders: ['@svgr/webpack'],
+        as: '*.js',
+      },
+    },
+  },
+}
+```
+
+For more details, refer to: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders


### PR DESCRIPTION
## Summary

This PR adds documentation about using SVGR with Next.js when using Turbopack as the bundler. While SVGR already works with Next.js using webpack, there are specific configuration requirements when using Turbopack that weren't previously documented. This addition will help developers who are migrating to Turbopack or starting new Next.js projects with Turbopack to properly integrate SVGR for SVG imports.

## Test plan

I've verified these instructions in a Next.js project using Turbopack by:
1. Setting up a basic Next.js project with Turbopack enabled
2. Implementing the configuration as documented
3. Successfully importing and rendering SVG files as React components

The documentation accurately reflects the steps needed to make SVGR work properly in this environment.
