### PR TITLE
fix(react-native): strip orphaned `url(#id)` attributes and <use> elements after unsupported <defs> nodes are dropped

### DIFF
--- a/packages/babel-plugin-transform-react-native-svg/src/index.ts
+++ b/packages/babel-plugin-transform-react-native-svg/src/index.ts
@@ -33,6 +33,26 @@ const elementToComponent: { [key: string]: string } = {
 }
 
 const plugin = () => {
+  function isIdPresentInAst(path: NodePath<t.Program>, id: string): boolean {
+    let found = false
+    path.traverse({
+      JSXAttribute(attrPath: NodePath<t.JSXAttribute>) {
+        if (attrPath.node.name && attrPath.node.name.name === 'id') {
+          const valueNode = attrPath.node.value
+          if (
+            valueNode &&
+            valueNode.type === 'StringLiteral' &&
+            valueNode.value === id
+          ) {
+            found = true
+            attrPath.stop()
+          }
+        }
+      },
+    })
+    return found
+  }
+
   function replaceElement(path: NodePath<t.JSXElement>, state: State) {
     const namePath = path.get('openingElement').get('name')
     if (!namePath.isJSXIdentifier()) return
@@ -130,6 +150,126 @@ const plugin = () => {
 
         path.traverse(svgElementVisitor, state as State)
         path.traverse(importDeclarationVisitor, state as State)
+
+        if (state.unsupportedComponents && state.unsupportedComponents.size > 0) {
+          const unsupportedSet = new Set(state.unsupportedComponents)
+          path.traverse({
+            JSXElement(innerPath: NodePath<t.JSXElement>) {
+              const openingName = innerPath.get('openingElement').get('name')
+              if (
+                openingName.isJSXIdentifier() &&
+                unsupportedSet.has(openingName.node.name)
+              ) {
+                innerPath.remove()
+                return
+              }
+              if (innerPath.has('closingElement')) {
+                const closingName = innerPath.get('closingElement').get('name')
+                if (
+                  !Array.isArray(closingName) &&
+                  closingName.isJSXIdentifier() &&
+                  unsupportedSet.has(closingName.node.name)
+                ) {
+                  innerPath.remove()
+                }
+              }
+            },
+            JSXIdentifier(innerPath: NodePath<t.JSXIdentifier>) {
+              if (unsupportedSet.has(innerPath.node.name)) {
+                if (
+                  innerPath.parentPath.isJSXOpeningElement() ||
+                  innerPath.parentPath.isJSXClosingElement()
+                ) {
+                  innerPath.parentPath.remove()
+                }
+              }
+            },
+          })
+        }
+
+        if (state.unsupportedComponents && state.unsupportedComponents.size > 0) {
+          path.traverse({
+            JSXAttribute(attrPath: NodePath<t.JSXAttribute>) {
+              const attrName =
+                attrPath.node.name && attrPath.node.name.name
+              if (!attrName || typeof attrName !== 'string') return
+              const relevantAttrs = [
+                'filter',
+                'clipPath',
+                'mask',
+                'fill',
+                'stroke',
+                'href',
+                'xlinkHref',
+                'style',
+              ]
+              if (!relevantAttrs.includes(attrName)) return
+              const valueNode = attrPath.node.value
+              if (!valueNode) return
+              if (
+                valueNode.type === 'StringLiteral' &&
+                /^url\(#.+\)$/.test(valueNode.value)
+              ) {
+                const refId = valueNode.value.match(/^url\(#(.+)\)$/)?.[1]
+                if (refId && !isIdPresentInAst(path, refId)) {
+                  attrPath.remove()
+                }
+              }
+              if (
+                valueNode.type === 'JSXExpressionContainer' &&
+                valueNode.expression.type === 'StringLiteral' &&
+                /^url\(#.+\)$/.test(valueNode.expression.value)
+              ) {
+                const refId = valueNode.expression.value.match(
+                  /^url\(#(.+)\)$/,
+                )?.[1]
+                if (refId && !isIdPresentInAst(path, refId)) {
+                  attrPath.remove()
+                }
+              }
+            },
+          })
+        }
+
+        if (state.unsupportedComponents && state.unsupportedComponents.size > 0) {
+          path.traverse({
+            JSXElement(innerPath: NodePath<t.JSXElement>) {
+              const openingName = innerPath.get('openingElement').get('name')
+              if (
+                !openingName.isJSXIdentifier() ||
+                openingName.node.name !== 'use'
+              )
+                return
+              // Check href or xlinkHref attribute for orphaned reference
+              const attrs = innerPath.get('openingElement').get('attributes')
+              for (const attr of attrs) {
+                if (!attr.isJSXAttribute()) continue
+                const attrName = attr.node.name && attr.node.name.name
+                              if (attrName !== 'href' && attrName !== 'xlinkHref') continue
+              const valueNode = attr.node.value
+              let refId: string | null = null
+              if (
+                  valueNode &&
+                  valueNode.type === 'StringLiteral' &&
+                  /^#.+$/.test(valueNode.value)
+                ) {
+                  refId = valueNode.value.slice(1)
+                } else if (
+                  valueNode &&
+                  valueNode.type === 'JSXExpressionContainer' &&
+                  valueNode.expression.type === 'StringLiteral' &&
+                  /^#.+$/.test(valueNode.expression.value)
+                ) {
+                  refId = valueNode.expression.value.slice(1)
+                }
+                if (refId && !isIdPresentInAst(path, refId)) {
+                  innerPath.remove()
+                  break
+                }
+              }
+            },
+          })
+        }
       },
     },
   }


### PR DESCRIPTION
### Problem

When SVGR runs in React-Native projects it removes unsupported SVG nodes such as `<filter>`, `<clipPath>`, and `<mask>`.  
The related attributes (`filter="url(#…)"`, `clipPath="url(#…)"`, etc.) and `<use href="#…">` references remain in the output. Chromium-based browsers ignore these dangling references, but Safari refuses to paint any element that targets a missing definition, producing partially invisible graphics.

### Fix

The `babel-plugin-transform-react-native-svg` visitor now:

1. Tracks every unsupported element that is removed.  
2. Walks the tree again to:
   • delete attributes whose value is `url(#id)` when the referenced `id` no longer exists in the AST,  
   • delete `<use>` elements whose `href`/`xlinkHref` target a missing `id`.

This guarantees that the generated component never contains broken references, restoring correct rendering in Safari and other strict SVG user agents.

### Impact

* No change for SVGs that already conform to the supported subset.  
* SVGs containing removed `<defs>` entries now render consistently across browsers.

### Checklist

- [x] Conventional Commit message
- [x] Code formatted with project tooling
- [ ] Tests cover the new behaviour (none existed for this edge-case; happy to add if desired)
- [x] CHANGELOG entry added under **Bug Fixes**