### PR TITLE
fix: update SVG module declaration to correct type in NextJS

### DIFF
--- a/website/pages/docs/next.mdx
+++ b/website/pages/docs/next.mdx
@@ -102,7 +102,7 @@ declare module '*.svg' {
 }
 
 declare module '*.svg?url' {
-  const content: any
+  const content: string
   export default content
 }
 ```


### PR DESCRIPTION
## Summary

Changes the type declaration for the `*.svg?url` from any to string.

## Test plan

- Imported SVGs as URLs (`import iconUrl from './icon.svg?url'`) and verified that the type is correctly inferred as string.
- Project builds and runs without type errors related to SVG imports.
