### PR TITLE
Replace `SVGProps<SVGSVGElement>` with `ComponentProps<'svg'>`

### DIFF
--- a/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-transform-svg-component/src/__snapshots__/index.test.ts.snap
@@ -332,7 +332,7 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "descProp" and "expandProps" adds "desc", "descId" props and expands props 1`] = `
 "import * as React from "react";
-import type { SVGProps } from "react";
+import type { ComponentProps } from "react";
 interface SVGRProps {
   desc?: string;
   descId?: string;
@@ -341,14 +341,14 @@ const SvgComponent = ({
   desc,
   descId,
   ...props
-}: SVGProps<SVGSVGElement> & SVGRProps) => <svg><g /></svg>;
+}: ComponentProps<'svg'> & SVGRProps) => <svg><g /></svg>;
 export default SvgComponent;"
 `;
 
 exports[`plugin typescript with "expandProps" add props 1`] = `
 "import * as React from "react";
-import type { SVGProps } from "react";
-const SvgComponent = (props: SVGProps<SVGSVGElement>) => <svg><g /></svg>;
+import type { ComponentProps } from "react";
+const SvgComponent = (props: ComponentProps<'svg'>) => <svg><g /></svg>;
 export default SvgComponent;"
 `;
 
@@ -411,9 +411,9 @@ export default ForwardRef;"
 
 exports[`plugin typescript with "ref" and "expandProps" option expands props 1`] = `
 "import * as React from "react";
-import type { SVGProps } from "react";
+import type { ComponentProps } from "react";
 import { Ref, forwardRef } from "react";
-const SvgComponent = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => <svg><g /></svg>;
+const SvgComponent = (props: ComponentProps<'svg'>, ref: Ref<SVGSVGElement>) => <svg><g /></svg>;
 const ForwardRef = forwardRef(SvgComponent);
 export default ForwardRef;"
 `;
@@ -428,7 +428,7 @@ export default ForwardRef;"
 
 exports[`plugin typescript with "titleProp" "descProp" and "expandProps" adds "title", "titleId", "desc", "descId" props and expands props 1`] = `
 "import * as React from "react";
-import type { SVGProps } from "react";
+import type { ComponentProps } from "react";
 interface SVGRProps {
   title?: string;
   titleId?: string;
@@ -441,7 +441,7 @@ const SvgComponent = ({
   desc,
   descId,
   ...props
-}: SVGProps<SVGSVGElement> & SVGRProps) => <svg><g /></svg>;
+}: ComponentProps<'svg'> & SVGRProps) => <svg><g /></svg>;
 export default SvgComponent;"
 `;
 
@@ -477,7 +477,7 @@ export default SvgComponent;"
 
 exports[`plugin typescript with "titleProp" and "expandProps" adds "title", "titleId" props and expands props 1`] = `
 "import * as React from "react";
-import type { SVGProps } from "react";
+import type { ComponentProps } from "react";
 interface SVGRProps {
   title?: string;
   titleId?: string;
@@ -486,7 +486,7 @@ const SvgComponent = ({
   title,
   titleId,
   ...props
-}: SVGProps<SVGSVGElement> & SVGRProps) => <svg><g /></svg>;
+}: ComponentProps<'svg'> & SVGRProps) => <svg><g /></svg>;
 export default SvgComponent;"
 `;
 

--- a/packages/babel-plugin-transform-svg-component/src/variables.ts
+++ b/packages/babel-plugin-transform-svg-component/src/variables.ts
@@ -49,15 +49,13 @@ const tsTypeReferenceSVGProps = (ctx: Context) => {
     )
     return t.tsTypeReference(identifier)
   }
-  const identifier = t.identifier('SVGProps')
+  const identifier = t.identifier('ComponentProps')
   getOrCreateImport(ctx, ctx.importSource, 'type').specifiers.push(
     t.importSpecifier(identifier, identifier),
   )
   return t.tsTypeReference(
     identifier,
-    t.tsTypeParameterInstantiation([
-      t.tsTypeReference(t.identifier('SVGSVGElement')),
-    ]),
+    t.tsTypeParameterInstantiation([t.tsTypeReference(t.identifier("'svg'"))]),
   )
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The `ComponentProps` generic type has become the standard for fetching native DOM types in TypeScript. This PR replaces the old `SVGProps<SVGSVGElement>` prop with the newer `ComponentProps<'svg'>` type. I personally find it much cleaner than the old way.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The new type `ComponentProps<'svg'>` is backward compatible and equivalent `SVGProps<SVGSVGElement>`, so there should be no issue with an update. If downstream packages are running tests that use a pure text diff, this could potentially cause issues with a type change, but in terms of functionality, this will cause no breakage in the usage of an SVG