### PR TITLE
fix(hast-util-to-babel-ast): preserve CSS custom property values

### DIFF
--- a/packages/hast-util-to-babel-ast/src/index.test.ts
+++ b/packages/hast-util-to-babel-ast/src/index.test.ts
@@ -93,11 +93,20 @@ describe('hast-util-to-babel-ast', () => {
     const code = `<svg><path style="--index: 1; font-size: 24px;"></path><path style="--index: 2"></path></svg>`
     expect(transform(code)).toMatchInlineSnapshot(`
       "<svg><path style={{
-          "--index": 1,
+          "--index": "1",
           fontSize: 24
         }} /><path style={{
-          "--index": 2
+          "--index": "2"
         }} /></svg>;"
     `)
+  })
+
+  it('preserves units in CSS custom property values', () => {
+    const code = `<svg style="--size: 20px; --spacing: 1.5rem; --width: 100%; --gradient: linear-gradient(red, blue);"></svg>`
+    const output = transform(code)
+    expect(output).toContain(`"--size": "20px"`)
+    expect(output).toContain(`"--spacing": "1.5rem"`)
+    expect(output).toContain(`"--width": "100%"`)
+    expect(output).toContain(`"--gradient": "linear-gradient(red, blue)"`)
   })
 })

--- a/packages/hast-util-to-babel-ast/src/stringToObjectStyle.ts
+++ b/packages/hast-util-to-babel-ast/src/stringToObjectStyle.ts
@@ -30,7 +30,8 @@ const formatKey = (key: string) => {
 /**
  * Format style value into JSX style object value.
  */
-const formatValue = (value: string) => {
+const formatValue = (value: string, key: string) => {
+  if (VAR_REGEX.test(key)) return t.stringLiteral(value)
   if (isNumeric(value)) return t.numericLiteral(Number(value))
   if (isConvertiblePixelValue(value))
     return t.numericLiteral(Number(trimEnd(value, 'px')))
@@ -53,7 +54,7 @@ export const stringToObjectStyle = (rawStyle: string): t.ObjectExpression => {
     const value = style.substr(firstColon + 1).trim()
     const key = style.substr(0, firstColon)
     if (key !== '') {
-      const property = t.objectProperty(formatKey(key), formatValue(value))
+      const property = t.objectProperty(formatKey(key), formatValue(value, key))
       properties.push(property)
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
- Preserve CSS custom property (`--*`) values as strings when converting inline styles.
- Add a regression test to ensure units like `px`, `rem`, `%`, and complex values are kept.

## Motivation
React does not auto-append units for CSS custom properties, so numeric conversion strips units and breaks rendering. This keeps `--*` values as raw strings.
>Note: CSS custom property values are now emitted as strings (e.g. `--index: 1` -> `"1"`).

## Test plan
- pnpm test -- packages/hast-util-to-babel-ast/src/index.test.ts

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Fixes #1020